### PR TITLE
announce expected services for BLE Linux binding

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -29,7 +29,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [ 20.x, 21.x]
+        node-version: [ 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,6 @@ jobs:
     - name: test 
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 24
     - run: echo "Setting up a new release"
       

--- a/package-lock.json
+++ b/package-lock.json
@@ -595,14 +595,14 @@
             "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -1276,9 +1276,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "build:cjs": "tsc -p tsconfig.cjs.json",
         "test": "vitest run",
         "test:unit": "vitest run --coverage",
-        "test:ci": "vitest run--coverage --forceExit",
+        "test:ci": "vitest run--coverage",
         "dev": "tsc -p tsconfig.esm.json --watch",
         "postversion": "git push && git push --tags",
         "protogen": "protoc --ts_out src/proto --proto_path protos protos/*.proto "

--- a/src/ble/base/interface.ts
+++ b/src/ble/base/interface.ts
@@ -579,7 +579,15 @@ export class BleInterface   extends EventEmitter implements IBleInterface<BlePer
 
         return new Promise( done =>{
             const ble = this.getBinding()
-            
+
+            // announce the supported services to bindings that need them upfront
+            // (e.g. WebBluetooth on Linux); noble bindings don't implement this
+            ble.setSupportedServices?.(this.expectedServices)
+            if (ble.setSupportedServices) {
+                const expectedServices = this.expectedServices??[]
+                const expected = expectedServices.join('|')
+                this.logEvent({message:'announce expected services',expected })
+            }
 
             ble.startScanning([], true,(err)=>{
                 if(err) {

--- a/src/ble/base/interface.unit.test.ts
+++ b/src/ble/base/interface.unit.test.ts
@@ -343,6 +343,18 @@ describe('BleInterface', () => {
             expect(logger.logEvent).toHaveBeenCalledWith({message:'starting peripheral discovery ...',interface:'ble'})
         })
 
+        test('binding with setSupportedServices gets the supported services announced before scanning', async () => {
+            setupMocks(i)
+            mocks.binding.setSupportedServices = jest.fn()
+
+            await waitForDevice(10)
+
+            expect(mocks.binding.setSupportedServices).toHaveBeenCalledWith(['0x1818','0x1826','0x180D','6E40FEC1-B5A3-F393-E0A9-E50E24DCCA9E'])
+            const announced = (mocks.binding.setSupportedServices as jest.Mock).mock.invocationCallOrder[0]
+            const scanned = (mocks.binding.startScanning as jest.Mock).mock.invocationCallOrder[0]
+            expect(announced).toBeLessThan(scanned)
+        })
+
         test('FTMS announced', async () => {
             setupMocks(i,{peripheral:FTMSPeripheral})
             const {device} = await waitForDevice()??{}

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -17,6 +17,16 @@ export interface BleBinding extends EventEmitter {
     _bindings: any;
     state: BleInterfaceState;
     on(eventName: string | symbol, listener: (...args: any[]) => void):this
+
+    /**
+     * Optional: announces the full set of BLE service UUIDs supported by this library.
+     *
+     * Bindings that must know the supported services upfront implement this —
+     * e.g. the WebBluetooth binding (Linux desktop), which has to pass them as
+     * `optionalServices` when requesting device access. Noble bindings do not
+     * implement it; callers must feature-detect (`binding.setSupportedServices?.(...)`).
+     */
+    setSupportedServices?(serviceUUIDs: string[]): void
 }
 
 


### PR DESCRIPTION
The Linux BLE Interface requires that the expected services are announced upfront, so that approval flow can be triggered correctly. This was added in thie PR