### PR TITLE
fix: bike start crash when a BLE notification subscribe needs a retry

### DIFF
--- a/src/direct-connect/base/peripheral.ts
+++ b/src/direct-connect/base/peripheral.ts
@@ -337,8 +337,8 @@ export class DirectConnectPeripheral implements IBlePeripheral {
         }
 
         for (const element of retry) {
-            const c = element
-            await this.subscribe(c.uuid, callback)
+            const uuid = element
+            await this.subscribe(uuid, callback)
         }
         return true
     }

--- a/src/direct-connect/base/peripheral.unit.test.ts
+++ b/src/direct-connect/base/peripheral.unit.test.ts
@@ -38,4 +38,45 @@ describe('DirectConnect Peripheral',()=>{
         })
 
     })
+
+    describe('subscribeSelected',()=>{
+
+        const announcement:MulticastDnsAnnouncement = {
+            type:'wahoo-fitness-tnp',
+            name:'TEST',
+            address:'192.168.1.1',
+            protocol:'tcp',
+            port:36866,
+            serialNo:'1234567',
+            serviceUUIDs:['0x1826'],
+            transport:'wifi'}
+
+        test('retries with the plain uuid string, not an object, when the initial subscribe fails',async ()=>{
+
+            const p = new DirectConnectPeripheral(announcement)
+
+            p.discoverServices = jest.fn(async ()=>['1826'])
+            p.discoverCharacteristics = jest.fn(async ()=>([
+                {uuid:'2AD2', properties:['notify']},
+                {uuid:'2ADA', properties:['notify']},
+            ]))
+
+            let firstAttemptDone = false
+            p.subscribe = jest.fn(async (uuid:string)=>{
+                if (uuid==='2ADA' && !firstAttemptDone) {
+                    firstAttemptDone = true
+                    return false // simulate a failed/unconfirmed first attempt
+                }
+                return true
+            })
+
+            const result = await p.subscribeSelected(['2AD2','2ADA'],()=>{})
+
+            expect(result).toBe(true)
+            // regression guard: retry must pass the uuid string itself, never undefined
+            expect(p.subscribe).toHaveBeenCalledWith('2ADA', expect.any(Function))
+            expect(p.subscribe).not.toHaveBeenCalledWith(undefined, expect.any(Function))
+        })
+
+    })
 })


### PR DESCRIPTION
## Summary
- Fixes a crash that aborted bike start whenever `subscribeSelected()` needed its retry path for a characteristic notification subscribe (observed on an FTMS "Think" trainer connected over the WiFi direct-connect bridge, characteristic `2ADA` Fitness Machine Status).
- The retry loop in `DirectConnectPeripheral.subscribeSelected()` treated `retry[]` entries as characteristic objects (`c.uuid`), but `retry[]` actually holds plain UUID strings pushed by the initial subscribe pass — so `c.uuid` was always `undefined`.
- That `undefined` was passed through `subscribe()` → `EnableCharacteristicNotificationsMessage.buildRequestBody()`, which calls `Buffer.from(undefined, "hex")` and throws: `The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type undefined`. This exception propagated up and failed the whole device start, forcing the user to cancel the ride.

## What changed
- `src/direct-connect/base/peripheral.ts`: retry loop now passes the UUID string itself (`this.subscribe(uuid, callback)`) instead of `c.uuid`.
- `src/direct-connect/base/peripheral.unit.test.ts`: added a regression test for `subscribeSelected()` asserting the retry attempt calls `subscribe()` with the plain UUID string, never `undefined`.

## Test plan
- [x] `npm test -- src/direct-connect/base/peripheral.unit.test.ts` — new test passes
- [x] `npm test` — full suite passes (51 files, 1096 passed / 35 skipped)