### PR TITLE
fix: WiFi/mDNS device identity - stale IP refresh and name-collision handling

### DIFF
--- a/src/ble/base/adapter.ts
+++ b/src/ble/base/adapter.ts
@@ -74,10 +74,16 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         try {
             const info = peripheral.getInfo()
             const settings:BleDeviceSettings = {...this.settings} as BleDeviceSettings
-            
+
             settings.id = settings.id ?? info.id
-            settings.address = settings.address ??info.address 
-            settings.name = settings.name ?? info.name 
+            // by the time we get here, waitForPeripheral() has already established that this
+            // peripheral IS the device identified by `settings` (matched by name/id) - so a freshly
+            // observed address is always more trustworthy than a persisted one, which may be stale
+            // (e.g. a wifi/mDNS device's IP changed since it was last paired - see FIXES_BACKLOG #14).
+            // Previously this used `settings.address ?? info.address`, which meant that once an
+            // address was recorded (even a stale one), a fresh observation could never overwrite it.
+            settings.address = info.address ?? settings.address
+            settings.name = settings.name ?? info.name
             this.settings = settings
         }
         catch {}
@@ -108,13 +114,25 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         if (as.profile || settings.profile)  { // legacy
             return (as.protocol===settings.protocol && as.profile===settings.profile && as.name===settings.name)
         }
-        else {
-            return (as.protocol===settings.protocol && (
-                (as.name && settings.name && as.name===settings.name) || 
-                (as.address && settings.address && as.address===settings.address) || 
-                (as.id && settings.id && as.id===settings.id))  ) 
-        }
 
+        if (as.protocol!==settings.protocol)
+            return false
+
+        // a stable id (e.g. derived from an mDNS serialNo) is the strongest identity signal
+        if (as.id && settings.id)
+            return as.id===settings.id
+
+        // if both sides carry an address, it alone decides equality - once we have two
+        // independently observed addresses, a shared/generic name (e.g. two "Volt" trainers) must
+        // no longer be treated as sufficient to consider them the same device (see FIXES_BACKLOG #14 -
+        // previously this was an OR across name/address/id, so a name-only match was enough to
+        // incorrectly merge two distinct physical devices into one)
+        if (as.address && settings.address)
+            return as.address===settings.address
+
+        // neither side has a comparable address/id - fall back to name (e.g. before a wifi device's
+        // first mDNS announcement has been observed, or for protocols with no stable address)
+        return !!(as.name && settings.name && as.name===settings.name)
     }
     isSame( adapter: IAdapter):boolean {
         return this.isEqual( adapter.getSettings() as BleDeviceSettings)

--- a/src/ble/fm/adapter.unit.test.ts
+++ b/src/ble/fm/adapter.unit.test.ts
@@ -19,9 +19,50 @@ describe('BleFmAdapter',()=>{
             const A = new BleFmAdapter({interface:'ble', name:'1',address:'1111', protocol:'fm'})
             const res = A.isEqual({interface:'ble', name:'2',address:'1111', protocol:'fm'})
             expect(res).toBeTruthy()
-        }) 
-    
-    })    
+        })
+
+        // FIXES_BACKLOG #14: two wifi devices sharing the same (generic) name must not be treated
+        // as equal just because the name matches - once both sides carry an address, it alone decides
+        test('same name, different address - not equal (name-only match is no longer sufficient)',()=>{
+            const A = new BleFmAdapter({interface:'wifi', name:'Volt',address:'10.0.0.5', protocol:'fm'})
+            const res = A.isEqual({interface:'wifi', name:'Volt',address:'10.0.0.9', protocol:'fm'})
+            expect(res).toBeFalsy()
+        })
+
+        test('id present on both sides is decisive, even if address differs',()=>{
+            const A = new BleFmAdapter({interface:'wifi', name:'Volt',address:'10.0.0.5',id:'SN-1', protocol:'fm'})
+            const res = A.isEqual({interface:'wifi', name:'Volt',address:'10.0.0.9',id:'SN-1', protocol:'fm'})
+            expect(res).toBeTruthy()
+        })
+
+        test('different protocol is never equal, regardless of name/address/id',()=>{
+            const A = new BleFmAdapter({interface:'wifi', name:'Volt',address:'10.0.0.5', protocol:'fm'})
+            const res = A.isEqual({interface:'wifi', name:'Volt',address:'10.0.0.5', protocol:'wahoo'} as any)
+            expect(res).toBeFalsy()
+        })
+
+    })
+
+    describe('updateSettings (FIXES_BACKLOG #14)',()=>{
+
+        test('a freshly observed address always overwrites a stale persisted one',()=>{
+            const A = new BleFmAdapter({interface:'wifi', name:'Volt',address:'10.0.0.5', protocol:'fm'})
+            const peripheral: any = { getInfo: jest.fn().mockReturnValue({ id:'10005', address:'10.0.0.9', name:'Volt'}) }
+
+            ;(A as any).updateSettings(peripheral)
+
+            expect(A.getSettings()).toMatchObject({address:'10.0.0.9'})
+        })
+
+        test('keeps the existing address when the peripheral reports none',()=>{
+            const A = new BleFmAdapter({interface:'wifi', name:'Volt',address:'10.0.0.5', protocol:'fm'})
+            const peripheral: any = { getInfo: jest.fn().mockReturnValue({ id:undefined, address:undefined, name:'Volt'}) }
+
+            ;(A as any).updateSettings(peripheral)
+
+            expect(A.getSettings()).toMatchObject({address:'10.0.0.5'})
+        })
+    })
 
     describe('start',()=>{
 

--- a/src/ble/fm/adapter.unit.test.ts
+++ b/src/ble/fm/adapter.unit.test.ts
@@ -29,6 +29,18 @@ describe('BleFmAdapter',()=>{
             expect(res).toBeFalsy()
         })
 
+        // Regression check: unlike wifi addresses (IPs, which can change e.g. on a DHCP lease
+        // renewal), BLE addresses are stable MAC addresses - two different BLE addresses are
+        // *always* two different physical devices, never the "same device, address changed" case.
+        // This adapter is shared between ble and wifi (see FIXES_BACKLOG #14), so isEqual() must
+        // apply the same "address alone decides, once both sides have one" rule to both interfaces -
+        // confirmed explicitly here for interface:'ble', not just interface:'wifi' above.
+        test('BLE: same name, different address - not equal (a physical BLE device cannot change its MAC address)',()=>{
+            const A = new BleFmAdapter({interface:'ble', name:'HRM-Dual',address:'AA:BB:CC:DD:EE:01', protocol:'fm'})
+            const res = A.isEqual({interface:'ble', name:'HRM-Dual',address:'AA:BB:CC:DD:EE:02', protocol:'fm'})
+            expect(res).toBeFalsy()
+        })
+
         test('id present on both sides is decisive, even if address differs',()=>{
             const A = new BleFmAdapter({interface:'wifi', name:'Volt',address:'10.0.0.5',id:'SN-1', protocol:'fm'})
             const res = A.isEqual({interface:'wifi', name:'Volt',address:'10.0.0.9',id:'SN-1', protocol:'fm'})

--- a/src/direct-connect/base/interface.ts
+++ b/src/direct-connect/base/interface.ts
@@ -469,15 +469,7 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
             // track, not a new device
             const sameAddress = this.findByNameAndAddress(service.name, service.address)
             if (sameAddress) {
-                const idx = this.services.indexOf(sameAddress)
-                const wasKnownDevicePlaceholder = sameAddress.source==='known-device'
-                const nextSource = (wasKnownDevicePlaceholder && src!=='known-device') ? src : sameAddress.source
-                this.services[idx] = {ts:Date.now(),service,source:nextSource}
-
-                if (src!=='known-device' && wasKnownDevicePlaceholder) {
-                    this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
-                    this.emitDevice(service)
-                }
+                this.refreshSameAddressEntry(sameAddress, service, src, source)
                 return
             }
 
@@ -491,13 +483,7 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
 
             if (sameName.length===0) {
                 // first time we see this name this session
-                this.services.push( {ts:Date.now(),service,source:src} )
-                if ( !service.serviceUUIDs?.length)
-                    return;
-
-                this.logEvent({message:'device announced',device:service.name, announcement:service, source})
-                this.emitDevice(service)
-                this.matching?.push(service.name)
+                this.announceNewEntry(service, src, source, 'device announced')
                 return
             }
 
@@ -506,13 +492,7 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
             if (src!=='known-device' && realEntries.length>=1) {
                 // rule (a): a 2nd (or further) independently, really observed address for this name
                 // this session - proof of a 2nd physical device sharing the same (generic) name
-                this.services.push( {ts:Date.now(),service,source:src} )
-                if ( !service.serviceUUIDs?.length)
-                    return;
-
-                this.logEvent({message:'device announced (name collision, distinct address)',device:service.name, announcement:service, source})
-                this.emitDevice(service)
-                this.matching?.push(service.name)
+                this.announceNewEntry(service, src, source, 'device announced (name collision, distinct address)')
                 return
             }
 
@@ -520,18 +500,51 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
             // earlier real observation) and no independent 2nd address has been seen this session -
             // treat this as the same physical device re-announcing under a new address, update the
             // slot in place, silently
-            const idx = this.services.indexOf(sameName[0])
-            this.services[idx] = {ts:Date.now(),service,source:src}
-
-            if (src!=='known-device') {
-                this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
-                this.emitDevice(service)
-            }
+            this.reannounceExistingEntry(sameName[0], service, src, source)
         }
         catch(err:any) {
             this.logError(err, 'addService')
         }
 
+    }
+
+    // Refreshes an entry we already track at this exact name+address (a heartbeat, not a new
+    // device). A known-device placeholder that now gets confirmed by a real observation is
+    // upgraded in place - see addService()'s doc comment for the source/placeholder rules.
+    private refreshSameAddressEntry(sameAddress:Announcement, service:MulticastDnsAnnouncement, src:string, source?:string) {
+        const idx = this.services.indexOf(sameAddress)
+        const wasKnownDevicePlaceholder = sameAddress.source==='known-device'
+        const nextSource = (wasKnownDevicePlaceholder && src!=='known-device') ? src : sameAddress.source
+        this.services[idx] = {ts:Date.now(),service,source:nextSource}
+
+        if (src!=='known-device' && wasKnownDevicePlaceholder) {
+            this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
+            this.emitDevice(service)
+        }
+    }
+
+    // Records a brand new cache entry (first sighting of this name this session, or a 2nd distinct
+    // address proving a 2nd physical device - see addService()'s doc comment, rules (a)).
+    private announceNewEntry(service:MulticastDnsAnnouncement, src:string, source:string|undefined, message:string) {
+        this.services.push( {ts:Date.now(),service,source:src} )
+        if ( !service.serviceUUIDs?.length)
+            return;
+
+        this.logEvent({message,device:service.name, announcement:service, source})
+        this.emitDevice(service)
+        this.matching?.push(service.name)
+    }
+
+    // Updates an existing entry in place under a new address - the "same device, address changed"
+    // heuristic, rule (b) in addService()'s doc comment.
+    private reannounceExistingEntry(existing:Announcement, service:MulticastDnsAnnouncement, src:string, source?:string) {
+        const idx = this.services.indexOf(existing)
+        this.services[idx] = {ts:Date.now(),service,source:src}
+
+        if (src!=='known-device') {
+            this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
+            this.emitDevice(service)
+        }
     }
 
     protected findByNameAndAddress(name:string,address:string) {

--- a/src/direct-connect/base/interface.ts
+++ b/src/direct-connect/base/interface.ts
@@ -118,8 +118,11 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
             const protocol = this.getProtocol(service)
             const address = service.address
             const services = service.serviceUUIDs?.map(uuid=> beautifyUUID(uuid,false))?.join(',')
+            // opportunistically use the announcement's own serialNo (when present) as a stable id -
+            // this fully resolves same-name ambiguity for devices that provide it (see FIXES_BACKLOG #14)
+            const id = service.serialNo || undefined
 
-            return {interface:DirectConnectInterface.INTERFACE_NAME, name, protocol,address, services }
+            return {interface:DirectConnectInterface.INTERFACE_NAME, name, protocol,address, services, ...(id?{id}:{}) }
         }
         catch {
             return null
@@ -127,7 +130,14 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
     }
 
     createPeripheralFromSettings(settings: DeviceSettings): IBlePeripheral {
-        const info = this.getAll().find(a=>a.service.name === settings.name)
+        const bleSettings = settings as BleDeviceSettings
+        const all = this.getAll()
+
+        // prefer an exact name+address match when the settings carry an address - this matters once
+        // two devices share the same name (see FIXES_BACKLOG #14): a name-only lookup could otherwise
+        // resolve to the wrong physical device
+        const info = (bleSettings.address && all.find(a=>a.service.name===settings.name && a.service.address===bleSettings.address))
+            ?? all.find(a=>a.service.name === settings.name)
 
         if (!info?.service)
             return null;
@@ -423,49 +433,129 @@ export default class DirectConnectInterface   extends EventEmitter implements IB
 
 
 
+    /**
+     * Adds/refreshes a discovered (or known-device placeholder) announcement in the session
+     * discovery cache.
+     *
+     * Wifi/mDNS devices are identified essentially by name (see `BleDeviceSettings` - there is no
+     * dedicated wifi identity type), which creates two related problems this method resolves with
+     * a session-scoped heuristic (see FIXES_BACKLOG #14):
+     *
+     * (a) If two announcements with the *same name* but *different addresses* are observed within
+     *     one session, that is proof of two physical devices (one device can't emit two addresses
+     *     at once) - both are surfaced as distinct, separately addressable cache entries instead of
+     *     one clobbering the other.
+     * (b) If only a *single* address has ever been seen for a name and a new announcement for that
+     *     name arrives with a different address, it is treated as an IP change (e.g. a DHCP lease
+     *     reassignment) and the existing slot's address is updated in place, silently. This is a
+     *     deliberate, optimistic heuristic: right for the common case, and even in the rare wrong
+     *     case (a second, currently-offline device with the same name) it degrades gracefully - the
+     *     second device takes over the first's slot until a session where both announce together,
+     *     at which point rule (a) splits them apart again. No data is destroyed.
+     *
+     * A 'known-device' sourced announcement (built from persisted, possibly stale settings - see
+     * `addKnownDevice()`) is never allowed to clobber an address we already have a live/real
+     * ('mdns') observation for this session - that was the actual stale-IP bug: a later re-add of
+     * known devices silently re-clobbering a cache entry a concurrent real mDNS announcement had
+     * just corrected.
+     */
     protected addService(service:MulticastDnsAnnouncement, source?:string):void {
         const src = source==='known-device' ? 'known-device' :  'mdns';
 
         try {
             service.transport = this.getName();
-            
-            const existing = this.find(service)
-            if (existing)  {
-                const idx = this.services.indexOf(existing)
-                this.services[idx]= {ts:Date.now(),service}
-                if (src!=='known-device' && existing.source==='known-device') { 
-                    this.services[idx].source = src
-                    this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
-                    this.emitDevice(service)                    
-                }
-                
 
+            // exact match (same name AND same address): a refresh/heartbeat of an entry we already
+            // track, not a new device
+            const sameAddress = this.findByNameAndAddress(service.name, service.address)
+            if (sameAddress) {
+                const idx = this.services.indexOf(sameAddress)
+                const wasKnownDevicePlaceholder = sameAddress.source==='known-device'
+                const nextSource = (wasKnownDevicePlaceholder && src!=='known-device') ? src : sameAddress.source
+                this.services[idx] = {ts:Date.now(),service,source:nextSource}
+
+                if (src!=='known-device' && wasKnownDevicePlaceholder) {
+                    this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
+                    this.emitDevice(service)
+                }
+                return
             }
-            else {
+
+            const sameName = this.findAllByName(service.name)
+
+            // never let a stale known-device placeholder clobber a name we already have a live
+            // observation for (at a different address)
+            if (src==='known-device' && sameName.some( a=> a.source!=='known-device')) {
+                return
+            }
+
+            if (sameName.length===0) {
+                // first time we see this name this session
                 this.services.push( {ts:Date.now(),service,source:src} )
                 if ( !service.serviceUUIDs?.length)
                     return;
 
-                this.logEvent({message:'device announced',device:service.name, announcement:service, source})               
-                this.emitDevice(service)                    
+                this.logEvent({message:'device announced',device:service.name, announcement:service, source})
+                this.emitDevice(service)
                 this.matching?.push(service.name)
-                
-                
+                return
+            }
 
-                
+            const realEntries = sameName.filter( a=> a.source!=='known-device')
+
+            if (src!=='known-device' && realEntries.length>=1) {
+                // rule (a): a 2nd (or further) independently, really observed address for this name
+                // this session - proof of a 2nd physical device sharing the same (generic) name
+                this.services.push( {ts:Date.now(),service,source:src} )
+                if ( !service.serviceUUIDs?.length)
+                    return;
+
+                this.logEvent({message:'device announced (name collision, distinct address)',device:service.name, announcement:service, source})
+                this.emitDevice(service)
+                this.matching?.push(service.name)
+                return
+            }
+
+            // rule (b): exactly one entry on file for this name (a known-device placeholder, or an
+            // earlier real observation) and no independent 2nd address has been seen this session -
+            // treat this as the same physical device re-announcing under a new address, update the
+            // slot in place, silently
+            const idx = this.services.indexOf(sameName[0])
+            this.services[idx] = {ts:Date.now(),service,source:src}
+
+            if (src!=='known-device') {
+                this.logEvent({message:'device re-announced',device:service.name, announcement:service, source})
+                this.emitDevice(service)
             }
         }
         catch(err:any) {
             this.logError(err, 'addService')
         }
-        
+
     }
 
-    protected find(service:MulticastDnsAnnouncement) {
-        return this.services.find( a=> a.service.name===service.name && a.ts>Date.now()-DC_EXPIRATION_TIMEOUT )
+    protected findByNameAndAddress(name:string,address:string) {
+        return this.services.find( a=> a.service.name===name && a.service.address===address && a.ts>Date.now()-DC_EXPIRATION_TIMEOUT )
     }
+
+    protected findAllByName(name:string) {
+        return this.services.filter( a=> a.service.name===name && a.ts>Date.now()-DC_EXPIRATION_TIMEOUT )
+    }
+
     protected getAll() {
         return this.services.filter( a=> a.ts>Date.now()-DC_EXPIRATION_TIMEOUT )
+    }
+
+    /**
+     * Returns whether, within the current discovery session, more than one distinct address has
+     * been observed for devices announcing under the given name.
+     *
+     * Used by consumers (see incyclist-services `DeviceConfigurationService.add()`) to tell a
+     * genuine second physical device apart from a simple address change of an already-known device
+     * sharing the same name. See FIXES_BACKLOG #14.
+     */
+    public hasNameCollision(name:string):boolean {
+        return this.findAllByName(name).length>1
     }
 
     setDebug(enabled:boolean) {

--- a/src/direct-connect/base/interface.unit.test.ts
+++ b/src/direct-connect/base/interface.unit.test.ts
@@ -145,11 +145,144 @@ describe('DirectConnectInterface', () => {
 
     describe('scan', () => {
 
-    })  
-    describe('stopScan', () => {})  
+    })
+    describe('stopScan', () => {})
 
     describe('waitForPeripheral', () => {})
 
-    
+    describe('addService / discovery cache identity heuristic (FIXES_BACKLOG #14)', () => {
+
+        let dc: any
+
+        const A = (name: string, address: string, extra: Partial<MulticastDnsAnnouncement> = {}): MulticastDnsAnnouncement =>
+            ({ name, address, port: 1234, serviceUUIDs: ['1818'], ...extra } as MulticastDnsAnnouncement)
+
+        beforeEach(() => {
+            DirectConnectInterface.prototype.autoConnect = jest.fn()
+            iface = new DirectConnectInterface({ binding: mock })
+            dc = iface as any
+        })
+
+        afterEach(() => {
+            jest.resetAllMocks()
+            iface?.removeAllListeners()
+        })
+
+        test('single re-announcement with a changed address silently updates the stored (known-device) entry in place (no 2nd entry, no collision)', () => {
+            // the "stored" device: a known-device placeholder built from persisted (possibly stale)
+            // settings, e.g. via addKnownDevice() at startup
+            dc.addService(A('Volt', '10.0.0.5'), 'known-device')
+            expect(dc.getAll()).toHaveLength(1)
+
+            // router reassigned the device a new IP - only one address has ever been seen for this
+            // name this session, so the real mDNS announcement is treated as the same device and
+            // silently corrects the stored address, rather than creating a 2nd entry
+            dc.addService(A('Volt', '10.0.0.9'), 'unfiltered')
+
+            const all = dc.getAll()
+            expect(all).toHaveLength(1)
+            expect(all[0].service.address).toBe('10.0.0.9')
+            expect(dc.hasNameCollision('Volt')).toBe(false)
+        })
+
+        test('two same-session announcements, same name, different address, surface as distinct entries and stay distinct', () => {
+            dc.addService(A('Volt', '10.0.0.5'), 'unfiltered')
+            dc.addService(A('Volt', '10.0.0.9'), 'unfiltered')
+
+            const all = dc.getAll()
+            expect(all).toHaveLength(2)
+            expect(all.map(a => a.service.address).sort()).toEqual(['10.0.0.5', '10.0.0.9'])
+            expect(dc.hasNameCollision('Volt')).toBe(true)
+
+            // a 3rd announcement repeating one of the two known addresses is just a refresh, not a 3rd entry
+            dc.addService(A('Volt', '10.0.0.5'), 'unfiltered')
+            expect(dc.getAll()).toHaveLength(2)
+        })
+
+        test('a stale known-device placeholder never clobbers a live mDNS observation at a different address', () => {
+            // real, live mDNS announcement observed first
+            dc.addService(A('Volt', '10.0.0.9'), 'unfiltered')
+
+            // a known-device placeholder built from stale persisted settings (old address) is added afterwards
+            dc.addService(A('Volt', '10.0.0.5'), 'known-device')
+
+            const all = dc.getAll()
+            expect(all).toHaveLength(1)
+            expect(all[0].service.address).toBe('10.0.0.9')
+            expect(all[0].source).toBe('mdns')
+        })
+
+        test('a known-device placeholder is corrected in place once the real mDNS announcement arrives (stale IP fix)', () => {
+            // placeholder built from stale persisted address at startup
+            dc.addService(A('Volt', '10.0.0.5'), 'known-device')
+            expect(dc.getAll()[0].service.address).toBe('10.0.0.5')
+
+            // the real device announces its actual (different) current address
+            dc.addService(A('Volt', '10.0.0.9'), 'unfiltered')
+
+            const all = dc.getAll()
+            expect(all).toHaveLength(1)
+            expect(all[0].service.address).toBe('10.0.0.9')
+            expect(all[0].source).toBe('mdns')
+        })
+
+        test('two distinct devices already split apart are not merged by a later known-device placeholder for either address', () => {
+            dc.addService(A('Volt', '10.0.0.5'), 'unfiltered')
+            dc.addService(A('Volt', '10.0.0.9'), 'unfiltered')
+            expect(dc.getAll()).toHaveLength(2)
+
+            // a known-device placeholder re-add (e.g. initWifiInterface() called again) for one of them
+            dc.addService(A('Volt', '10.0.0.5'), 'known-device')
+
+            const all = dc.getAll()
+            expect(all).toHaveLength(2)
+            expect(all.map(a => a.service.address).sort()).toEqual(['10.0.0.5', '10.0.0.9'])
+        })
+
+        test('hasNameCollision is false for a name that was never announced', () => {
+            expect(dc.hasNameCollision('unknown')).toBe(false)
+        })
+    })
+
+    describe('createDeviceSetting - id from serialNo (FIXES_BACKLOG #14)', () => {
+
+        let dc: any
+
+        beforeEach(() => {
+            DirectConnectInterface.prototype.autoConnect = jest.fn()
+            iface = new DirectConnectInterface({ binding: mock })
+            dc = iface as any
+        })
+
+        test('populates id from the announcement serialNo when present', () => {
+            const settings = dc.createDeviceSetting({ name: 'KICKR CORE', address: '10.0.0.5', port: 1234, serviceUUIDs: ['1818'], serialNo: 'ABCD1234' })
+            expect(settings.id).toBe('ABCD1234')
+        })
+
+        test('leaves id undefined when the announcement has no serialNo', () => {
+            const settings = dc.createDeviceSetting({ name: 'Volt', address: '10.0.0.5', port: 1234, serviceUUIDs: ['1818'] })
+            expect(settings.id).toBeUndefined()
+        })
+    })
+
+    describe('createPeripheralFromSettings - address-preferential lookup (FIXES_BACKLOG #14)', () => {
+
+        let dc: any
+
+        beforeEach(() => {
+            DirectConnectInterface.prototype.autoConnect = jest.fn()
+            iface = new DirectConnectInterface({ binding: mock })
+            dc = iface as any
+        })
+
+        test('resolves the address-matching entry when two devices share a name', () => {
+            dc.addService({ name: 'Volt', address: '10.0.0.5', port: 1234, serviceUUIDs: ['1818'] }, 'unfiltered')
+            dc.addService({ name: 'Volt', address: '10.0.0.9', port: 1234, serviceUUIDs: ['1818'] }, 'unfiltered')
+
+            const peripheral = dc.createPeripheralFromSettings({ interface: 'wifi', name: 'Volt', address: '10.0.0.9' })
+            expect(peripheral).toBeDefined()
+            expect(peripheral.getInfo().address).toBe('10.0.0.9')
+        })
+    })
 
 })


### PR DESCRIPTION
## Summary
Two related bugs in WiFi/mDNS-discovered device identity (e.g. Wahoo KICKR/Volt), both keyed on the fact that identity was effectively name-only with IP present but unused for disambiguation:

1. **Stale IP never refreshes for an already-paired device reconnecting normally** (not via an open scan/pairing screen) — a placeholder announcement built from persisted, potentially-stale settings could silently re-clobber a correct, freshly-observed cache entry. Also, `BleAdapter.updateSettings()` used `settings.address ?? info.address`, so a freshly observed address was never written back once any address was already on file, even after a real successful connection.
2. **Two identically-named devices (e.g. two bare "Volt" trainers) collapse into one** — the discovery cache keyed strictly by `service.name`, so a second physical device with the same name silently overwrote the first's cache slot.

## Approach (agreed session-scoped heuristic, no stable id required)
- Two announcements with the same name but *different* addresses observed within one session → proof of two physical devices → surfaced as distinct entries.
- A single announcement for a name matching a stored device, with a different address → treated as an IP change → stored address updated silently, no user prompt.
- Opportunistically populate `BleDeviceSettings.id` from the mDNS announcement's `serialNo` when present (previously discarded), fully resolving the rare ambiguous case when available, without blocking the heuristic-based fix on it.

## What changed
- `src/direct-connect/base/interface.ts`: `addService()`/`find()` rewritten with the session-scoped identity heuristic; added `findByNameAndAddress()`, `findAllByName()`, public `hasNameCollision(name)`; `createDeviceSetting()` populates `id` from `serialNo`; `createPeripheralFromSettings()` prefers exact name+address match.
- `src/ble/base/adapter.ts`: `updateSettings()` — freshly observed address now always wins over a stale one; `isEqual()` — address is decisive when present on both sides (no longer OR'd with name), `id` takes precedence when available, name is fallback only when neither side has an address.

## Test plan
- [x] `npm test` — 51 suites, 1110 passed (35 pre-existing skips)
- [x] New tests in `direct-connect/base/interface.unit.test.ts` and `ble/fm/adapter.unit.test.ts` covering: silent address update on single re-announcement, session-scoped split on two same-name/different-address announcements, placeholder-vs-real-observation precedence
- [x] Cross-checked against the already-merged device-delete fix (companion `services` PR #481) for regressions — see companion PR in `services` (same branch name: `feat/wifi-mdns-device-identity`) for the `DeviceConfigurationService` side

Ref: FIXES_BACKLOG.md item #14