### PR TITLE
fix: FTMS Control Point handshake before data-wait timeout

### DIFF
--- a/src/ble/base/adapter.ts
+++ b/src/ble/base/adapter.ts
@@ -371,8 +371,14 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         // to be implemeted by controllable adapters
     }
 
-    protected async initControl(_props?:BleStartProperties):Promise<void> {        
+    protected async initControl(_props?:BleStartProperties):Promise<void> {
         // to be implemeted by controllable adapters
+    }
+
+    protected async initControlBestEffort(_props?:BleStartProperties):Promise<void> {
+        // to be implemented by controllable adapters that support a best-effort control handshake
+        // for devices that have been downgraded (e.g. FTMS Power Meter-only devices - see
+        // BleFmAdapter.initControlBestEffort, FIXES_BACKLOG #22)
     }
 
     protected getStartLogProps(props:BleStartProperties):BleStartProperties {
@@ -424,12 +430,30 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
                 return false
             }
 
-            await this.waitForInitialData(timeout)
-            await this.checkCapabilities()        
+            // FIXES_BACKLOG #22: checkCapabilities() (a GATT read, not dependent on notification data)
+            // must run before waitForInitialData(), so the FTMS Control Point handshake
+            // (RequestControl/StartOrResume) can be attempted *before* the data-wait timeout, not only
+            // after it - some FTMS firmwares won't start streaming Indoor Bike Data notifications at all
+            // until that handshake has happened.
+            await this.checkCapabilities()
             const skipControl = this.props.capabilities && !this.props.capabilities.includes(IncyclistCapability.Control);
-            if ( this.hasCapability( IncyclistCapability.Control)  && !skipControl)
+            const isControllable = this.hasCapability( IncyclistCapability.Control) && !skipControl
+
+            if (isControllable) {
+                // controllable devices: RequestControl gates pairing success - initControl() is
+                // expected to throw if control could not be established within its own dedicated
+                // timeout, failing pairing fast (caught below) rather than silently exhausting the
+                // whole data-wait timeout.
                 await this.initControl(startProps)
-                   
+            }
+            else {
+                // devices without a settable target (already downgraded, e.g. FTMS Power Meter-only):
+                // attempt the same handshake best-effort - any outcome is only logged, never fatal.
+                // waitForInitialData() below remains the sole arbiter of pairing success for these.
+                await this.initControlBestEffort(startProps)
+            }
+
+            await this.waitForInitialData(timeout)
 
             this.stopped = false;    
             this.started = true;

--- a/src/ble/fm/adapter.ts
+++ b/src/ble/fm/adapter.ts
@@ -11,6 +11,7 @@ import { BleDeviceProperties, BleDeviceSettings, BleStartProperties, IBlePeriphe
 import { IAdapter,IncyclistCapability,IncyclistAdapterData,IncyclistBikeData, ITrainer } from '../../types/index.js';
 import { LegacyProfile } from '../../antv2/types.js';
 import { sleep } from '../../utils/utils.js';
+import { InteruptableTask, TaskState } from '../../utils/task.js';
 import { BleZwiftPlaySensor } from '../zwift/play/index.js';
 import { useFeatureToggle } from '../../features/index.js';
 import FMResistanceMode from '../../modes/fm-resistance.js';
@@ -23,6 +24,11 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
     protected distanceInternal: number = 0;
     protected connectPromise: Promise<boolean>|undefined
     protected requestControlRetryDelay = 1000
+    // FIXES_BACKLOG #22: dedicated bound for the RequestControl handshake, so a trainer that rejects
+    // or never answers RequestControl fails pairing fast, instead of silently burning the whole
+    // (much longer) shared pairing timeout - restores the ~10s bound removed as a side effect of
+    // commit b6fa461 (2024-12-21)
+    protected requestControlTimeout = 10000
     protected promiseSendUpdate: Promise<UpdateRequest|void>|undefined
     protected zwiftPlay: BleZwiftPlaySensor|undefined
     protected isHubInitialized: boolean = false
@@ -227,11 +233,60 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
 
         // In some cases, the device does not support fitness machine features, which might have been detected in checkCapabilities()
         // therefore we need to check if we still have control capabilties
-        if (!this.hasCapability(IncyclistCapability.Control)) 
+        if (!this.hasCapability(IncyclistCapability.Control))
             return;
 
-        await this.establishControl();        
-        await this.sendInitialRequest()        
+        // RequestControl is the only step that gates pairing success: a controllable trainer that
+        // rejects/never answers it fails fast (establishControl() throws, bounded by
+        // requestControlTimeout - FIXES_BACKLOG #22).
+        await this.establishControl();
+
+        // StartOrResume ("start session") is required by some FTMS firmwares before they start
+        // streaming Indoor Bike Data notifications at all - but its outcome must never fail pairing,
+        // only RequestControl does (FIXES_BACKLOG #22).
+        await this.attemptStartRequest()
+
+        await this.sendInitialRequest()
+    }
+
+    /**
+     * Best-effort counterpart of initControl(), used for devices that have already been downgraded to
+     * Power Meter (checkCapabilities() found no settable power/slope/resistance target). Some FTMS
+     * firmwares still require the RequestControl/StartOrResume handshake before they start streaming
+     * Indoor Bike Data at all, even though they have nothing controllable to offer - so we still attempt
+     * it, but any outcome (success, rejection, or no response) is only logged, never fatal:
+     * waitForInitialData() remains the sole arbiter of pairing success for these devices
+     * (FIXES_BACKLOG #22).
+     */
+    protected async initControlBestEffort(_startProps?:BleStartProperties) {
+        if (!this.isStarting())
+            return;
+
+        this.setConstants();
+
+        try {
+            const hasControl = await this.getSensor().requestControl()
+            if (hasControl) {
+                this.logEvent({message:'control granted (downgraded device)', device:this.getName(), interface:this.getInterface()})
+                await this.attemptStartRequest()
+            }
+            else {
+                this.logEvent({message:'could not establish control (downgraded device, non-fatal)', device:this.getName(), interface:this.getInterface()})
+            }
+        }
+        catch(err) {
+            this.logEvent({message:'could not establish control (downgraded device, non-fatal)', device:this.getName(), interface:this.getInterface(), error:(err as Error).message})
+        }
+    }
+
+    protected async attemptStartRequest() {
+        try {
+            const started = await this.getSensor().startRequest()
+            this.logEvent({message: started ? 'start request acknowledged' : 'start request not acknowledged (non-fatal)', device:this.getName(), interface:this.getInterface()})
+        }
+        catch(err) {
+            this.logEvent({message:'start request failed (non-fatal)', device:this.getName(), interface:this.getInterface(), error:(err as Error).message})
+        }
     }
 
     protected setConstants() {
@@ -250,16 +305,16 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
         }
     }
 
-    protected async establishControl() {
+    protected async establishControl():Promise<boolean> {
         if (!this.isStarting())
             return false
 
         let hasControl = false
         let tryCnt = 0;
-        
+
         const sensor = this.getSensor();
 
-        return new Promise<boolean>( (resolve) =>{
+        const controlPromise = new Promise<boolean>( (resolve) =>{
 
 
             this.startTask.notifyOnStop(() => {
@@ -276,8 +331,8 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
                     if (tryCnt++ === 0) {
                         this.logEvent( {message:'requesting control', device:this.getName(), interface:this.getInterface()})
                     }
-                    hasControl = await sensor.requestControl();    
-                    if (hasControl) {                        
+                    hasControl = await sensor.requestControl();
+                    if (hasControl) {
                         this.logEvent( {message:'control granted', device:this.getName(), interface:this.getInterface()})
                         resolve( this.isStarting() )
                     }
@@ -285,11 +340,30 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
                         await sleep(this.requestControlRetryDelay)
                     }
                 }
-    
+
             }
-            waitUntilControl()                
+            waitUntilControl()
         })
 
+        // FIXES_BACKLOG #22: bound the RequestControl handshake with its own dedicated timeout, instead
+        // of relying entirely on the (much longer) shared outer pairing timeout to ever stop it. If it
+        // is still starting (i.e. this isn't just an ordinary stop/interrupt) and control was never
+        // granted within that window, fail fast with an explicit error.
+        const waitTask = new InteruptableTask<TaskState,boolean>( controlPromise, {
+            timeout: this.requestControlTimeout,
+            name: 'establishControl',
+            errorOnTimeout: false,
+            log: this.logEvent.bind(this)
+        })
+
+        const granted = await waitTask.run()
+
+        if (!granted && this.isStarting()) {
+            this.logEvent({message:'could not establish control', device:this.getName(), interface:this.getInterface()})
+            throw new Error('could not establish control')
+        }
+
+        return granted
     }
 
     protected async sendInitialRequest() {

--- a/src/ble/fm/adapter.unit.test.ts
+++ b/src/ble/fm/adapter.unit.test.ts
@@ -2,6 +2,7 @@ import { sleep } from '../../utils/utils'
 import { IBleInterface } from '../types'
 import BleFmAdapter from './adapter'
 import BleFitnessMachineDevice from './sensor'
+import { IncyclistCapability } from '../../types/index'
 describe('BleFmAdapter',()=>{
     describe('isEqual',()=>{
 
@@ -100,14 +101,20 @@ describe('BleFmAdapter',()=>{
         sensor.stopSensor= jest.fn().mockReturnValue(true)
         sensor.setSlope = jest.fn().mockReturnValue(true)
         sensor.setTargetPower = jest.fn().mockResolvedValue(true)
+        sensor.startRequest = jest.fn().mockResolvedValue(true)
 
         let adapter: BleFmAdapter
         let iv
 
         const setupMocks= (a)=>{
-            a.getSensor = jest.fn( ()=> { return sensor})            
+            a.getSensor = jest.fn( ()=> { return sensor})
             a.getBle = jest.fn().mockReturnValue(ble)
             a.requestControlRetryDelay = 10;
+            // keep the dedicated RequestControl timeout short in tests (FIXES_BACKLOG #22), so a
+            // scenario where control is never granted doesn't leave a real 10s timer running in the
+            // background after the test has already finished (the outer/shared pairing timeout used in
+            // most of these tests is much shorter and will still win the race where relevant)
+            a.requestControlTimeout = 300;
             if (process.env.DEBUG) {
                 a.logger = {logEvent:(message)=>console.log( new Date().toISOString(),{...message})}
                 sensor.logEvent = a.logger.logEvent
@@ -184,10 +191,140 @@ describe('BleFmAdapter',()=>{
 
             expect(adapter.started).toBeFalsy()
             expect(waitForData).toHaveBeenCalled()
-            expect(establishControl).not.toHaveBeenCalled()
-            
+            // FIXES_BACKLOG #22: checkCapabilities()/initControl() now run *before* waitForInitialData(),
+            // so establishControl() is reached (and starts retrying RequestControl) before the stop()
+            // call interrupts it - unlike before the reorder, where a stop during the (then-first)
+            // data-wait meant establishControl() was never reached at all. It must still resolve
+            // gracefully (no throw, no control granted) once stopped, rather than fail pairing.
+            expect(establishControl).toHaveBeenCalled()
         })
 
+
+    })
+
+    describe('start - FTMS Control Point handshake (FIXES_BACKLOG #22)',()=>{
+
+        let sensor: BleFitnessMachineDevice
+        let ble: Partial<IBleInterface<any>>
+        let adapter: BleFmAdapter
+        let iv
+
+        const setupMocks = (a) => {
+            a.getSensor = jest.fn( ()=> sensor)
+            a.getBle = jest.fn().mockReturnValue(ble)
+            a.requestControlRetryDelay = 10
+        }
+
+        const emitDataContinuously = () => {
+            iv = setInterval( ()=> { sensor.emit('data',{power:0}) }, 10)
+        }
+
+        beforeEach( ()=>{
+            sensor = new BleFitnessMachineDevice(null)
+            sensor.subscribe = jest.fn().mockResolvedValue(true)
+            sensor.setCrr = jest.fn()
+            sensor.setCw = jest.fn()
+            sensor.hasPeripheral = jest.fn().mockReturnValue(true)
+            sensor.reset = jest.fn()
+            sensor.startSensor = jest.fn().mockReturnValue(true)
+            sensor.stopSensor = jest.fn().mockReturnValue(true)
+            sensor.setSlope = jest.fn().mockReturnValue(true)
+            sensor.setTargetPower = jest.fn().mockResolvedValue(true)
+
+            ble = {
+                once: jest.fn(),
+                pauseLogging: jest.fn(),
+                resumeLogging: jest.fn(),
+                removeListener: jest.fn(),
+                connect: jest.fn().mockResolvedValue(true),
+                createPeripheralFromSettings: jest.fn(),
+                waitForPeripheral: jest.fn().mockResolvedValue({})
+            }
+
+            adapter = new BleFmAdapter({interface:'ble', name:'1', address:'1111', protocol:'fm'})
+        })
+
+        afterEach( async ()=>{
+            if (iv)
+                clearInterval(iv)
+            await adapter.stop()
+        })
+
+        test('controllable device: RequestControl never granted fails pairing fast, bounded by the dedicated control timeout - not the (much larger) default data-wait timeout',async ()=>{
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0}   // no downgrade info -> stays controllable
+            sensor.requestControl = jest.fn().mockResolvedValue(false)
+            sensor.startRequest = jest.fn().mockResolvedValue(true)
+            setupMocks(adapter)
+            ;(adapter as any).requestControlTimeout = 100   // dedicated control timeout, kept short for the test
+            emitDataContinuously()
+
+            const tsStart = Date.now()
+            // no startProps.timeout given -> outer pairing timeout falls back to getDefaultStartupTimeout() (30s);
+            // if the failure were still bounded by that (the pre-fix bug), this test would need to wait 30s
+            const result = await adapter.start()
+            const duration = Date.now() - tsStart
+
+            expect(result).toBe(false)
+            expect(adapter.started).toBeFalsy()
+            expect(duration).toBeLessThan(2000)
+
+            // must fail fast, before ever attempting the non-fatal StartOrResume handshake or the
+            // existing target-setting write
+            expect(sensor.startRequest).not.toHaveBeenCalled()
+            expect(sensor.setSlope).not.toHaveBeenCalled()
+        })
+
+        test('controllable device: RequestControl succeeds but StartOrResume fails - not fatal, pairing proceeds normally',async ()=>{
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0}
+            sensor.requestControl = jest.fn().mockResolvedValue(true)
+            sensor.startRequest = jest.fn().mockRejectedValue(new Error('write failed'))
+            setupMocks(adapter)
+            emitDataContinuously()
+
+            const result = await adapter.start({timeout:2000})
+
+            expect(result).toBe(true)
+            expect(adapter.started).toBeTruthy()
+            expect(sensor.requestControl).toHaveBeenCalled()
+            expect(sensor.startRequest).toHaveBeenCalled()
+        })
+
+        test('downgraded (power-meter-only) device: RequestControl rejected/never granted is only logged, never fails pairing',async ()=>{
+            // features explicitly report no settable target -> checkCapabilities() downgrades to Power Meter
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0, setPower:false, setSlope:false, setResistance:false}
+            sensor.requestControl = jest.fn().mockRejectedValue(new Error('control not permitted'))
+            sensor.startRequest = jest.fn()
+            setupMocks(adapter)
+            emitDataContinuously()
+
+            const result = await adapter.start({timeout:2000})
+
+            expect(result).toBe(true)
+            expect(adapter.started).toBeTruthy()
+            expect(adapter.hasCapability(IncyclistCapability.Control)).toBeFalsy()  // sanity check: genuinely downgraded
+
+            expect(sensor.requestControl).toHaveBeenCalled()
+            // best-effort only: a rejected RequestControl must never block/fail waitForInitialData,
+            // and (since RequestControl itself failed) StartOrResume is not attempted either
+            expect(sensor.startRequest).not.toHaveBeenCalled()
+        })
+
+        test('checkCapabilities() runs before waitForInitialData() in the overall start sequence',async ()=>{
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0}
+            sensor.requestControl = jest.fn().mockResolvedValue(true)
+            sensor.startRequest = jest.fn().mockResolvedValue(true)
+            setupMocks(adapter)
+            emitDataContinuously()
+
+            const checkCapabilities = jest.spyOn(adapter as any,'checkCapabilities')
+            const waitForData = jest.spyOn(adapter as any,'waitForInitialData')
+
+            await adapter.start({timeout:2000})
+
+            expect(checkCapabilities).toHaveBeenCalled()
+            expect(waitForData).toHaveBeenCalled()
+            expect(checkCapabilities.mock.invocationCallOrder[0]).toBeLessThan(waitForData.mock.invocationCallOrder[0])
+        })
 
     })
 })

--- a/src/ble/fm/sensor.ts
+++ b/src/ble/fm/sensor.ts
@@ -158,10 +158,13 @@ export default class BleFitnessMachineDevice extends TBleSensor {
         if (!this.isSubscribed())
             return false
 
-        // If we know from features flag that setPower and setSlope are not supported, just ignore
-        if (this.features?.setPower===false && this.features?.setSlope===false && this.features?.setResistance===false) {
-            return true;
-        }
+        // Note: previously, devices whose features flag reported setPower/setSlope/setResistance all
+        // false (i.e. no controllable resistance) short-circuited here, returning true without ever
+        // writing to the Control Point. Some FTMS firmwares require a RequestControl (and StartOrResume)
+        // handshake before they start streaming Indoor Bike Data at all, independent of whether the
+        // device has settable targets - so the write is now always attempted. Callers that only need
+        // this best-effort for such devices (see BleFmAdapter.initControlBestEffort) are responsible for
+        // treating a false/failed outcome as non-fatal (FIXES_BACKLOG #22).
 
         this.logEvent( {message:'requestControl'})
         this.isCheckingControl = true;


### PR DESCRIPTION
## Summary

- BLE FTMS bikes that require a Control Point handshake (`RequestControl`, `StartOrResume`) before they start streaming Indoor Bike Data notifications were timing out during pairing, because `startAdapter()` ran the 30s `waitForInitialData()` wait *before* `checkCapabilities()`/`initControl()` - so no Control Point write happened at all during the entire data-wait window, for any FTMS device.
- Reported case: a "Sports24 S24 spin bike" (BLE name `FIT-5274`) connects and subscribes to Indoor Bike Data (`0x2AD2`) and FTMS Status (`0x2ADA`) successfully, then never receives any data and times out after 30s.
- Fixes `FIXES_BACKLOG.md` item #22 (see that file for the full root-cause write-up).

## What changed

- `src/ble/base/adapter.ts`: `startAdapter()` now calls `checkCapabilities()` **before** `waitForInitialData()`, then branches:
  - Controllable devices (declare a settable power/slope/resistance target): `initControl()`.
  - Devices without a settable target (already downgraded to Power Meter): new `initControlBestEffort()` hook (no-op by default, matches prior behaviour for non-FTMS profiles).
- `src/ble/fm/adapter.ts`:
  - `establishControl()` now has its own dedicated ~10s timeout (`requestControlTimeout`) and throws `could not establish control` if `RequestControl` is rejected/never answered within it - restoring behaviour removed as a side effect of `b6fa461` (2024-12-21), but now on a wider surface so pairing fails fast instead of silently exhausting the full pairing timeout.
  - `initControl()` now also calls the new `attemptStartRequest()` (sends `StartOrResume` via `sensor.startRequest()`) after `establishControl()` succeeds - a failure here is only logged, never fatal.
  - New `initControlBestEffort()` override: for devices already downgraded to Power Meter, attempts `RequestControl` + `StartOrResume` best-effort - any outcome (success, rejection, timeout) is only logged, never fails pairing. `waitForInitialData()` remains the sole arbiter of pairing success for these devices.
- `src/ble/fm/sensor.ts`: `requestControl()` no longer short-circuits (skipping the actual write) for devices whose features report no settable target - the write is now genuinely attempted for all devices; callers decide whether a failure is fatal.

## Test plan

- [x] `npm test` (vitest) - full suite: 51 test files, 1115 passed / 35 skipped (pre-existing skips, unrelated)
- [x] `src/ble/fm/adapter.unit.test.ts` extended with new coverage:
  - Controllable device: `RequestControl` never granted fails pairing fast, bounded by the dedicated ~100ms-in-test control timeout, not the 30s default data-wait timeout.
  - Controllable device: `RequestControl` succeeds but `StartOrResume` fails - not fatal, pairing proceeds normally.
  - Downgraded (Power Meter-only) device: `RequestControl` rejected/never granted is only logged, never fails pairing.
  - `checkCapabilities()` now runs before `waitForInitialData()` (call-order assertion).
  - Updated `stop during start` test: since `checkCapabilities()`/`initControl()` now run before `waitForInitialData()`, `establishControl()` is reached before a mid-start `stop()`, unlike before the reorder - updated the assertion to match, and confirmed it still resolves gracefully (no throw, no control granted) rather than failing pairing.
- [ ] Validate against real FTMS hardware (a genuinely controllable trainer, and ideally a Power Meter-only device like the reported S24) - not done as part of this change, flagged in `FIXES_BACKLOG.md` #22 as needed before closing out the item.

Companion fix in `incyclist-services` on the same branch name (`feat/ftms-start-handshake`): a stale-capability-persistence bug found while diagnosing this (`DeviceConfigurationService.updateCapabilities()`).