### PR TITLE
fix: serialize BleAdapter start()/stop() to prevent concurrent GATT collisions

### DIFF
--- a/src/ble/base/adapter.ts
+++ b/src/ble/base/adapter.ts
@@ -21,6 +21,11 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
     protected onDeviceDisconnectHandler = this.emit.bind(this)
     protected onDisconnectDoneHandler = this.onDisconnectDone.bind(this)
     protected startTask: InteruptableTask<TaskState,boolean>;
+    // FIXES_BACKLOG #23: tracks an in-flight start()/stop() call so concurrent invocations on the
+    // same adapter instance can converge on (dedupe against) the one already running, instead of
+    // each launching their own duplicate startAdapter()/teardown run.
+    protected startPromise?: Promise<boolean>;
+    protected stopPromise?: Promise<boolean>;
     constructor( settings:BleDeviceSettings, props?:DeviceProperties) {
         super(settings,props)
 
@@ -295,15 +300,27 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         return 'connected'
     }
 
-    async start( startProps?: BleStartProperties ): Promise<boolean> { 
+    async start( startProps?: BleStartProperties ): Promise<boolean> {
 
-        if (this.isStarting()) {
-            await this.stop()
+        // FIXES_BACKLOG #23: if a stop() is currently in flight for this adapter, wait for its
+        // *real* completion (i.e. the previous run's underlying startAdapter() promise has
+        // genuinely settled - see stop() below) before deciding what to do. Loop rather than a
+        // single await: once we resume, another concurrent start()/stop() may already have moved
+        // the state further along (e.g. kicked off a fresh stop of its own).
+        while (this.stopPromise) {
+            await this.stopPromise
+        }
+
+        // a start is already in flight and no stop is pending - don't force a stop+restart (that
+        // was the bug): converge concurrent start() calls onto the one already running instead of
+        // launching a duplicate startAdapter() run.
+        if (this.isStarting() && this.startPromise) {
+            return this.startPromise
         }
 
         const ble = this.getBle()
-        
-        
+
+
         ble.once('disconnect-done',this.onDisconnectDoneHandler)
 
         this.startTask = new InteruptableTask( this.startAdapter(startProps), {
@@ -313,12 +330,22 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
             log: this.logEvent.bind(this)
         })
 
-        const res = await this.startTask.run()
+        this.startPromise = this.runStartTask(ble)
+        return this.startPromise
+    }
 
-        if (!res) {
-            ble.removeListener('disconnect-done',this.onDisconnectDoneHandler)
+    protected async runStartTask(ble:IBleInterface<any>): Promise<boolean> {
+        try {
+            const res = await this.startTask.run()
+
+            if (!res) {
+                ble.removeListener('disconnect-done',this.onDisconnectDoneHandler)
+            }
+            return res;
         }
-        return res;
+        finally {
+            this.startPromise = undefined
+        }
     }
 
     protected isStarting():boolean {
@@ -555,36 +582,68 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
 
     }
 
-    async stop(): Promise<boolean> { 
+    async stop(): Promise<boolean> {
+
+        // FIXES_BACKLOG #23: dedupe concurrent stop() calls on the same adapter instance - share
+        // one in-flight stop rather than running the teardown logic (sensor.reset(), listener
+        // removal, etc.) a second time.
+        if (this.stopPromise) {
+            return this.stopPromise
+        }
+
+        this.stopPromise = this.runStop()
+        try {
+            return await this.stopPromise
+        }
+        finally {
+            this.stopPromise = undefined
+        }
+    }
+
+    protected async runStop(): Promise<boolean> {
         this.logEvent( {message:'stopping device', device:this.getName(),interface:this.getInterface()})
 
         if (this.isStarting()) {
-            await this.startTask.stop()
+            const task = this.startTask
+
+            // signal the in-flight start to stop: this flips InteruptableTask's internal
+            // isRunning flag and resolves its wrapper promise, so isStarting() correctly becomes
+            // false and the in-flight startAdapter() sees (via its own isStarting() checks) that
+            // it has been interrupted once it reaches them.
+            await task.stop()
+
+            // FIXES_BACKLOG #23: the flag flip above does NOT mean the actual startAdapter() work
+            // (e.g. an already-dispatched BLE GATT write still awaiting its response) has finished
+            // - await the raw wrapped promise too, so stop() itself doesn't resolve until the
+            // prior run has genuinely settled (completed, errored, or hit its own timeout). Without
+            // this, a subsequent start() could begin while the previous run's GATT operations were
+            // still physically in flight, colliding with them.
+            await task.getUnderlyingPromise()?.catch(()=>{})
         }
 
         // make sure that we restart upon next start() call, even if the stop fails
         this.started = false;
         this.resetData()
-        
+
         if (!this.getSensor()) {
-            this.logEvent( {message:'device stopped - not started yet', device:this.getName(),interface:this.getInterface()})    
+            this.logEvent( {message:'device stopped - not started yet', device:this.getName(),interface:this.getInterface()})
             return true;
         }
         const sensor = this.getSensor();
 
 
-        sensor.off('data',this.onDeviceDataHandler) 
+        sensor.off('data',this.onDeviceDataHandler)
         sensor.off('disconnected', this.onDeviceDisconnectHandler)
-        sensor.off('error',console.log) 
+        sensor.off('error',console.log)
         const ble = this.getBle()
         ble.removeListener('disconnect-done',this.onDisconnectDoneHandler)
 
         sensor.reset();
-        this.resetData()        
+        this.resetData()
         this.stopped = true
         this.started = false
 
-        this.logEvent( {message:'device stopped', device:this.getName(),interface:this.getInterface()})    
+        this.logEvent( {message:'device stopped', device:this.getName(),interface:this.getInterface()})
         return this.stopped
     }
 

--- a/src/ble/base/adapter.ts
+++ b/src/ble/base/adapter.ts
@@ -307,14 +307,14 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         // genuinely settled - see stop() below) before deciding what to do. Loop rather than a
         // single await: once we resume, another concurrent start()/stop() may already have moved
         // the state further along (e.g. kicked off a fresh stop of its own).
-        while (this.stopPromise) {
+        while (this.stopPromise !== undefined) {
             await this.stopPromise
         }
 
         // a start is already in flight and no stop is pending - don't force a stop+restart (that
         // was the bug): converge concurrent start() calls onto the one already running instead of
         // launching a duplicate startAdapter() run.
-        if (this.isStarting() && this.startPromise) {
+        if (this.isStarting() && this.startPromise !== undefined) {
             return this.startPromise
         }
 
@@ -587,7 +587,7 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         // FIXES_BACKLOG #23: dedupe concurrent stop() calls on the same adapter instance - share
         // one in-flight stop rather than running the teardown logic (sensor.reset(), listener
         // removal, etc.) a second time.
-        if (this.stopPromise) {
+        if (this.stopPromise !== undefined) {
             return this.stopPromise
         }
 

--- a/src/ble/fm/adapter.unit.test.ts
+++ b/src/ble/fm/adapter.unit.test.ts
@@ -327,4 +327,136 @@ describe('BleFmAdapter',()=>{
         })
 
     })
+
+    // FIXES_BACKLOG #23: BleAdapter.start()/stop() must genuinely serialize concurrent calls on the
+    // same adapter instance - real-device validation against a controllable FTMS trainer ("Volt")
+    // showed the entire checkCapabilities()/establishControl()/requestControl() sequence firing
+    // twice, ~4ms apart, producing two concurrent RequestControl BLE writes that collided at the
+    // GATT layer.
+    describe('start/stop concurrency (FIXES_BACKLOG #23)',()=>{
+
+        let sensor: BleFitnessMachineDevice
+        let ble: Partial<IBleInterface<any>>
+        let adapter: BleFmAdapter
+        let iv
+
+        const setupMocks = (a) => {
+            a.getSensor = jest.fn( ()=> sensor)
+            a.getBle = jest.fn().mockReturnValue(ble)
+            a.requestControlRetryDelay = 10
+        }
+
+        const emitDataContinuously = () => {
+            iv = setInterval( ()=> { sensor.emit('data',{power:0}) }, 10)
+        }
+
+        beforeEach( ()=>{
+            sensor = new BleFitnessMachineDevice(null)
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0}
+            sensor.subscribe = jest.fn().mockResolvedValue(true)
+            sensor.setCrr = jest.fn()
+            sensor.setCw = jest.fn()
+            sensor.hasPeripheral = jest.fn().mockReturnValue(true)
+            sensor.reset = jest.fn()
+            sensor.startSensor = jest.fn().mockReturnValue(true)
+            sensor.stopSensor = jest.fn().mockReturnValue(true)
+            sensor.setSlope = jest.fn().mockReturnValue(true)
+            sensor.setTargetPower = jest.fn().mockResolvedValue(true)
+            sensor.requestControl = jest.fn().mockResolvedValue(true)
+            sensor.startRequest = jest.fn().mockResolvedValue(true)
+
+            ble = {
+                once: jest.fn(),
+                pauseLogging: jest.fn(),
+                resumeLogging: jest.fn(),
+                removeListener: jest.fn(),
+                connect: jest.fn().mockResolvedValue(true),
+                createPeripheralFromSettings: jest.fn(),
+                waitForPeripheral: jest.fn().mockResolvedValue({})
+            }
+
+            adapter = new BleFmAdapter({interface:'ble', name:'1', address:'1111', protocol:'fm'})
+        })
+
+        afterEach( async ()=>{
+            if (iv)
+                clearInterval(iv)
+            await adapter.stop()
+        })
+
+        test('overlapping start() calls converge on one result - no duplicate startAdapter()/GATT work',async ()=>{
+            setupMocks(adapter)
+            emitDataContinuously()
+
+            const p1 = adapter.start({timeout:2000})
+            const p2 = adapter.start({timeout:2000})
+
+            const [r1,r2] = await Promise.all([p1,p2])
+
+            expect(r1).toBe(true)
+            expect(r2).toBe(true)
+            // the second start() must have converged onto the first's in-flight run, rather than
+            // launching its own duplicate startAdapter() - so every GATT-level operation below
+            // must only have happened once
+            expect(ble.connect).toHaveBeenCalledTimes(1)
+            expect(sensor.startSensor).toHaveBeenCalledTimes(1)
+            expect(sensor.requestControl).toHaveBeenCalledTimes(1)
+        })
+
+        test('start() called while a stop() is in flight waits for the REAL completion of that stop (not just an internal flag flip) before proceeding',async ()=>{
+            setupMocks(adapter)
+            emitDataContinuously()
+
+            let resolveConnect: (v:boolean)=>void
+            const connectDeferred = new Promise<boolean>( resolve => { resolveConnect = resolve })
+            let connectCallCount = 0
+            ble.connect = jest.fn().mockImplementation( ()=> {
+                connectCallCount++
+                return connectCallCount===1 ? connectDeferred : Promise.resolve(true)
+            })
+
+            // p1 gets stuck mid-flight, awaiting connect() - simulates a still in-flight GATT
+            // operation (e.g. an already-dispatched RequestControl write awaiting its response)
+            const p1 = adapter.start({timeout:5000})
+            await sleep(20)
+            expect(connectCallCount).toBe(1)
+
+            // stop() while p1 is still genuinely running underneath
+            const stopPromise = adapter.stop()
+            await sleep(20)
+
+            // InteruptableTask's internal isRunning flag has already flipped to false by now (it
+            // does so synchronously) - but the real work (still awaiting connectDeferred) has not
+            // finished. A second start() must wait for stop()'s genuine completion, not this flag.
+            const p2 = adapter.start({timeout:5000})
+            await sleep(30)
+
+            expect(connectCallCount).toBe(1)   // p2 must NOT have proceeded to a fresh connect() yet
+
+            // let the first run's connect() (and the whole chain depending on it) finally settle
+            resolveConnect(true)
+
+            await stopPromise
+            await Promise.all([p1,p2])
+
+            expect(connectCallCount).toBeGreaterThanOrEqual(2)   // p2 eventually did proceed
+        })
+
+        test('concurrent stop() calls dedupe - teardown logic only runs once',async ()=>{
+            setupMocks(adapter)
+            emitDataContinuously()
+
+            await adapter.start({timeout:2000})
+            expect(adapter.started).toBeTruthy()
+
+            const s1 = adapter.stop()
+            const s2 = adapter.stop()
+
+            const [r1,r2] = await Promise.all([s1,s2])
+
+            expect(r1).toBe(r2)
+            expect(sensor.reset).toHaveBeenCalledTimes(1)
+        })
+
+    })
 })

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -49,8 +49,24 @@ export class InteruptableTask<T extends TaskState, P > {
         this.start()
     }
 
-    getPromise():Promise<P> {    
+    getPromise():Promise<P> {
         return this.internalState.promise;
+    }
+
+    /**
+     * Returns the raw promise this task was constructed with (e.g. the actual async operation -
+     * such as `startAdapter()` - still executing underneath).
+     *
+     * Unlike `getPromise()`/`run()`, which settle as soon as the task is told to stop or hits its
+     * timeout (i.e. they only reflect that the caller no longer wants to keep waiting), this
+     * promise only settles once the wrapped work has genuinely finished executing - completed,
+     * thrown, or otherwise done. Callers that need to know the underlying work has *truly*
+     * finished (not just been signalled to stop) should await this instead (see
+     * FIXES_BACKLOG #23 - `BleAdapter.stop()` uses this to avoid resolving before a still in-flight
+     * `startAdapter()` run has actually settled).
+     */
+    getUnderlyingPromise():Promise<any>|undefined {
+        return this.promise;
     }
 
     getState():T {

--- a/src/utils/task.unit.test.ts
+++ b/src/utils/task.unit.test.ts
@@ -1,0 +1,78 @@
+import { InteruptableTask } from './task'
+
+describe('InteruptableTask', ()=>{
+
+    describe('getUnderlyingPromise (FIXES_BACKLOG #23)', ()=>{
+
+        // FIXES_BACKLOG #23: BleAdapter.stop() needs a way to know when the *actual* wrapped
+        // async work (e.g. a still in-flight startAdapter() call) has genuinely finished, as
+        // opposed to run()/getPromise(), which settle as soon as stop() is called (i.e. only
+        // reflect that the caller no longer wants to keep waiting). getUnderlyingPromise() exposes
+        // the raw promise the task was constructed with, so it can be awaited for that purpose.
+
+        test('returns the raw promise passed to the constructor', ()=>{
+            const raw = Promise.resolve(true)
+            const task = new InteruptableTask<any,boolean>(raw, { errorOnTimeout:false })
+
+            expect(task.getUnderlyingPromise()).toBe(raw)
+        })
+
+        test('does not settle when stop() is called - only once the underlying work genuinely finishes', async ()=>{
+            let resolveRaw: (v:boolean)=>void
+            const raw = new Promise<boolean>( resolve => { resolveRaw = resolve })
+            const task = new InteruptableTask<any,boolean>(raw, { errorOnTimeout:false })
+
+            let underlyingSettled = false
+            task.getUnderlyingPromise().then( ()=> { underlyingSettled = true })
+
+            // stop() resolves the task's own wrapper promise (run()/getPromise()) almost
+            // immediately - but the underlying raw work is still pending
+            await task.stop()
+            expect(underlyingSettled).toBe(false)
+
+            // now let the underlying work genuinely finish
+            resolveRaw(true)
+            await task.getUnderlyingPromise()
+
+            expect(underlyingSettled).toBe(true)
+        })
+
+        test('run()/getPromise() settle on stop() well before the underlying promise does', async ()=>{
+            let resolveRaw: (v:boolean)=>void
+            const raw = new Promise<boolean>( resolve => { resolveRaw = resolve })
+            const task = new InteruptableTask<any,boolean>(raw, { errorOnTimeout:false })
+
+            // capture the wrapper promise the way a real caller (e.g. BleAdapter.start()) does -
+            // before stop() is ever called
+            const runPromise = task.run()
+
+            const stopped = await task.stop()
+            expect(stopped).toBe(true)
+
+            // the wrapper/run() promise has already resolved via stop() - the raw promise
+            // underneath is a completely separate, still-pending promise
+            const result = await runPromise
+            expect(result).toBeNull()
+
+            // clean up the still-pending raw promise so it doesn't leak between tests
+            resolveRaw(true)
+            await task.getUnderlyingPromise()
+        })
+
+        test('settles with an error if the underlying work rejects', async ()=>{
+            let rejectRaw: (e:Error)=>void
+            const raw = new Promise<boolean>( (_resolve,reject) => { rejectRaw = reject })
+            const task = new InteruptableTask<any,boolean>(raw, { errorOnTimeout:false })
+            // the rejection also propagates to the task's own wrapper promise (run()/getPromise()) -
+            // consume it here so it doesn't surface as an unrelated unhandled-rejection warning
+            task.getPromise()?.catch( ()=>{} )
+
+            const err = new Error('gatt operation already in progress')
+            rejectRaw(err)
+
+            await expect(task.getUnderlyingPromise()).rejects.toThrow('gatt operation already in progress')
+        })
+
+    })
+
+})


### PR DESCRIPTION
## Summary

- Fixes `FIXES_BACKLOG` item #23: `BleAdapter.start()`/`stop()` didn't actually serialize concurrent calls on the same adapter instance, allowing two overlapping `start()` runs to collide at the BLE GATT layer (confirmed via real-device testing against a "Volt" FTMS trainer, discovered while validating item #22 — the Control Point handshake reorder made this pre-existing race collide almost every time instead of almost never).
- Root cause: `start()`'s guard `if (this.isStarting()) { await this.stop() }` assumed `stop()` halted the previous in-flight run. In reality, `InteruptableTask.stop()` only flipped its internal `isRunning` flag and resolved its own wrapper promise — it never awaited the real `startAdapter()` promise still executing underneath (e.g. an already-dispatched `RequestControl` write awaiting its GATT response). So a second `start()` call could proceed while the first's GATT operation was still physically in flight.

## What changed

`src/utils/task.ts`
- Added `InteruptableTask.getUnderlyingPromise()` — exposes the raw promise the task was constructed with. Purely additive; existing consumers (`ble/base/interface.ts`, `ble/fm/adapter.ts`, `ble/fm/sensor.ts`, `direct-connect/base/interface.ts`, `direct-connect/base/peripheral.ts`) are unaffected, no existing method signature or behavior changed.

`src/ble/base/adapter.ts`
- `stop()`: after signalling the in-flight task to stop (flips the flag), now also awaits `task.getUnderlyingPromise()` so `stop()` doesn't resolve until the prior run has genuinely settled (completed, errored, or timed out) — not just flag-flipped. Concurrent `stop()` calls dedupe via a shared `stopPromise`, so teardown logic (`sensor.reset()`, listener removal, etc.) only runs once.
- `start()`: if a `stop()` is currently in flight, awaits its *real* completion (via the shared `stopPromise`) before re-evaluating. If a `start()` is already in flight and no stop is pending, converges onto the existing in-flight run's result (via a shared `startPromise`) instead of forcing a stop+restart — this is what eliminates the duplicate `startAdapter()`/GATT collision.

## Test plan

- [x] Added `src/utils/task.unit.test.ts`: covers `getUnderlyingPromise()` — returns the raw constructor promise, stays pending across `stop()` (unlike `run()`/`getPromise()`), settles once the real work finishes, propagates rejection.
- [x] Added a `start/stop concurrency (FIXES_BACKLOG #23)` describe block to `src/ble/fm/adapter.unit.test.ts`:
  - Overlapping `start()` calls converge on one result with no duplicate GATT-level work (`connect`/`startSensor`/`requestControl` each called exactly once).
  - A `start()` call arriving while a `stop()` is in flight waits for the stop's *real* completion (not just the internal flag flip) before proceeding.
  - Concurrent `stop()` calls dedupe — teardown (`sensor.reset()`) runs only once.
- [x] Full existing suite still green: `npm test` → 52 test files, 1122 passed, 35 skipped.
- [ ] Real-device validation against the "Volt" FTMS trainer (the scenario that surfaced this) — confirm the log no longer shows a duplicated `RequestControl`/GATT collision. Not done as part of this PR; flagging for manual verification before merge per workspace convention.

Note: per a scope correction from the reviewing user during implementation, the originally-planned secondary defense-in-depth fix in `incyclist-services` (`DevicePairingService.startPairing()`'s `usage!=='page'` guard conditions) was dropped — that guard split is intentional (page-mode is driven by mobile's own state machine and must not be silently no-op'd), and the `services`-side await chain was independently confirmed already correct. This PR is `devices`-only.