### PR TITLE
fix: cancel orphaned RequestControl writes and stop leaking 'data' listeners

### DIFF
--- a/src/ble/base/peripheral.ts
+++ b/src/ble/base/peripheral.ts
@@ -584,7 +584,7 @@ export class BlePeripheral implements IBlePeripheral {
 
             const cleanup = () => {
                 if (onData) {
-                    c.removeListener('data', onData)
+                    c.off('data', onData)
                     onData = undefined
                 }
                 signal?.removeEventListener('abort', onAbort)

--- a/src/ble/base/peripheral.ts
+++ b/src/ble/base/peripheral.ts
@@ -569,38 +569,84 @@ export class BlePeripheral implements IBlePeripheral {
             }
         }
 
+        const signal = options?.signal
 
         return new Promise( (resolve,reject) => {
 
+            // FIXES_BACKLOG #25: a write that is abandoned (timed out or explicitly cancelled via
+            // `signal`) must not leave its 'data' listener attached to `c` forever - `c` is the same,
+            // reused characteristic object across adapter generations, so a leaked listener here
+            // survives long past this call and can steal a later, unrelated write's real response.
+            // `onData` holds the *specific* listener reference this call attached, so cleanup only
+            // ever removes its own listener - never a concurrent/later write's.
+            let settled = false
+            let onData: ((data:Buffer)=>void)|undefined
+
+            const cleanup = () => {
+                if (onData) {
+                    c.removeListener('data', onData)
+                    onData = undefined
+                }
+                signal?.removeEventListener('abort', onAbort)
+            }
+
+            const settleResolve = (result:Buffer) => {
+                if (settled) return
+                settled = true
+                cleanup()
+                resolve(result)
+            }
+
+            const settleReject = (err:Error) => {
+                if (settled) return
+                settled = true
+                cleanup()
+                reject(err)
+            }
+
+            const onAbort = () => {
+                settleReject(new Error('aborted'))
+            }
+
+            if (signal) {
+                if (signal.aborted) {
+                    settleReject(new Error('aborted'))
+                    return
+                }
+                signal.addEventListener('abort', onAbort, {once:true})
+            }
+
             const write = () => {
-                if (this.disconnecting || !this.connected)
-                    return Promise.resolve(Buffer.from([]))
-        
-                c.on('data', (data)=>{
-                    c.removeAllListeners('data')
-                    resolve(data)
-                })
+                if (this.disconnecting || !this.connected) {
+                    settleResolve(Buffer.from([]))
+                    return
+                }
+
+                onData = (responseData:Buffer) => {
+                    settleResolve(responseData)
+                }
+                c.on('data', onData)
 
                 this.logEvent({message:'write request', characteristic:uuid, data:data.toString('hex'), withoutResponse:options?.withoutResponse===true})
-    
+
                 c.write( data, options?.withoutResponse===true,(err) =>{
-                    if (err) 
-                        reject(err)
+                    if (err)
+                        settleReject(err)
                 })
 
                 if (options?.withoutResponse) {
-                    resolve(Buffer.from([]))
-                }   
+                    settleResolve(Buffer.from([]))
+                }
 
             }
 
             if ( !options?.withoutResponse ) {
-                this.subscribe(characteristicUUID,null).then( success => {
+                this.subscribe(characteristicUUID,null).then( () => {
                     write()
                 })
             }
             else {
-                write() 
+                write()
             }
 
         })

--- a/src/ble/base/peripheral.unit.test.ts
+++ b/src/ble/base/peripheral.unit.test.ts
@@ -1,0 +1,154 @@
+import { EventEmitter } from 'events'
+import { BlePeripheral } from './peripheral'
+import { beautifyUUID } from '../utils'
+import { BleCharacteristic, BleProperty } from '../types'
+
+// Minimal noble-style characteristic mock - a plain EventEmitter, matching
+// `BleRawCharacteristic extends BleCharacteristic, EventEmitter` (src/ble/types.ts).
+class MockChar extends EventEmitter implements BleCharacteristic {
+    uuid: string
+    properties: BleProperty[] = ['write', 'notify']
+    name?: string
+
+    constructor(uuid: string) {
+        super()
+        this.uuid = uuid
+    }
+
+    subscribe(callback: (err: Error | undefined) => void): void {
+        callback(undefined)
+    }
+    unsubscribe(callback: (err: Error | undefined) => void): void {
+        callback(undefined)
+    }
+    read(callback: (err: Error | undefined, data: Buffer) => void): void {
+        callback(undefined, Buffer.from([]))
+    }
+    write(_data: Buffer, _withoutResponse: boolean, callback?: (err: Error | undefined) => void): void {
+        callback?.(undefined)
+    }
+}
+
+const CP = '2AD9'   // FTMS Control Point - the shared characteristic at the centre of FIXES_BACKLOG #25
+
+describe('BlePeripheral', () => {
+
+    describe('write (FIXES_BACKLOG #25)', () => {
+
+        const setup = () => {
+            const announcement: any = { peripheral: { id: 'p1', address: 'AA:BB:CC:DD:EE:FF' }, serviceUUIDs: [] }
+            const p: any = new BlePeripheral(announcement)
+            p.connected = true
+            p.logEvent = () => {}
+
+            const c = new MockChar(CP)
+            p.characteristics = { [beautifyUUID(CP)]: c }
+            p.subscribe = vi.fn().mockResolvedValue(true)
+
+            return { p, c }
+        }
+
+        test('a successful write resolves with the response and removes its own listener', async () => {
+            const { p, c } = setup()
+
+            const promise = p.write(CP, Buffer.from([0x00]))
+            // give the subscribe().then(write) chain a tick to attach the listener
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(c.listenerCount('data')).toBe(1)
+
+            const response = Buffer.from([0x80, 0x00, 0x01])
+            c.emit('data', response)
+
+            await expect(promise).resolves.toEqual(response)
+            expect(c.listenerCount('data')).toBe(0)
+        })
+
+        test('a write-callback error rejects the promise and removes its own listener', async () => {
+            const { p, c } = setup()
+
+            c.write = (_data: Buffer, _withoutResponse: boolean, callback?: (err: Error | undefined) => void) => {
+                callback?.(new Error('gatt write failed'))
+            }
+
+            const promise = p.write(CP, Buffer.from([0x00]))
+
+            await expect(promise).rejects.toThrow('gatt write failed')
+            expect(c.listenerCount('data')).toBe(0)
+        })
+
+        test('an abandoned/timed-out write (aborted via signal) does not leave a dangling listener', async () => {
+            const { p, c } = setup()
+
+            const controller = new AbortController()
+            const promise = p.write(CP, Buffer.from([0x00]), { timeout: 5000, signal: controller.signal })
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(c.listenerCount('data')).toBe(1)
+
+            controller.abort()
+
+            await expect(promise).rejects.toThrow('aborted')
+            expect(c.listenerCount('data')).toBe(0)
+        })
+
+        test('aborting an already-settled write is a harmless no-op (idempotent settle)', async () => {
+            const { p, c } = setup()
+
+            const controller = new AbortController()
+            const promise = p.write(CP, Buffer.from([0x00]), { signal: controller.signal })
+            await Promise.resolve()
+            await Promise.resolve()
+
+            const response = Buffer.from([0x80, 0x00, 0x01])
+            c.emit('data', response)
+            await expect(promise).resolves.toEqual(response)
+
+            // aborting after the fact must not throw or double-settle
+            expect(() => controller.abort()).not.toThrow()
+        })
+
+        // FIXES_BACKLOG #25 - the critical regression test: the old implementation cleaned up via
+        // `c.removeAllListeners('data')`, called *inside* the listener itself - so an abandoned write
+        // that is later cancelled/settled would wipe out every listener on the shared characteristic,
+        // including a concurrent, still-legitimately-pending write's own listener. The fix removes
+        // only the calling write's own specific listener reference, so a later, unrelated write on the
+        // same (reused) characteristic is completely unaffected by an earlier one being abandoned.
+        test('an earlier abandoned write does not steal or discard a later, unrelated write\'s real response', async () => {
+            const { p, c } = setup()
+
+            // attempt A: issued first, then abandoned (its owning caller gave up and cancelled it) -
+            // mirrors establishControl()'s dedicated timeout cancelling an in-flight requestControl()
+            const controllerA = new AbortController()
+            const writeA = p.write(CP, Buffer.from([0x00]), { timeout: 5000, signal: controllerA.signal })
+            await Promise.resolve()
+            await Promise.resolve()
+
+            // attempt B: a second, later write on the very same characteristic object - e.g. a fresh
+            // pairing generation's own RequestControl retry, while A's is still (about to be) abandoned
+            const writeB = p.write(CP, Buffer.from([0x00]))
+            await Promise.resolve()
+            await Promise.resolve()
+
+            // both writes are genuinely concurrent at this point - two listeners on the one shared `c`
+            expect(c.listenerCount('data')).toBe(2)
+
+            // A gives up (its dedicated timeout fires) - this must remove *only* A's own listener
+            controllerA.abort()
+            await expect(writeA).rejects.toThrow('aborted')
+            expect(c.listenerCount('data')).toBe(1)
+
+            // the real response now arrives - meant for B, the only genuinely outstanding request
+            const realResponse = Buffer.from([0x80, 0x00, 0x01])
+            c.emit('data', realResponse)
+
+            // B must resolve with the real response - not be silently discarded by A's cleanup
+            await expect(writeB).resolves.toEqual(realResponse)
+            expect(c.listenerCount('data')).toBe(0)
+        })
+
+    })
+
+})

--- a/src/ble/fm/adapter.ts
+++ b/src/ble/fm/adapter.ts
@@ -314,10 +314,27 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
 
         const sensor = this.getSensor();
 
+        // FIXES_BACKLOG #25: `cancelled`/`controlAbort` let every "give up" path (the dedicated
+        // timeout below, or the adapter itself being stopped) both (a) stop the retry loop from
+        // iterating again, immediately - not just eventually, once `isStarting()` catches up - and
+        // (b) genuinely cancel whatever `sensor.requestControl()` call is currently in flight,
+        // instead of abandoning it to keep running (and holding its 'data' listener on the shared
+        // Control Point characteristic) on its own, much longer, internal timeline. `abandon()` is
+        // idempotent so it is safe to call from more than one of these paths.
+        let cancelled = false
+        const controlAbort = new AbortController()
+        const abandon = () => {
+            if (cancelled)
+                return
+            cancelled = true
+            controlAbort.abort()
+        }
+
         const controlPromise = new Promise<boolean>( (resolve) =>{
 
 
             this.startTask.notifyOnStop(() => {
+                abandon()
                 resolve(false)
             })
 
@@ -327,16 +344,16 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
                 }
 
 
-                while (!hasControl && this.isStarting()) {
+                while (!hasControl && !cancelled && this.isStarting()) {
                     if (tryCnt++ === 0) {
                         this.logEvent( {message:'requesting control', device:this.getName(), interface:this.getInterface()})
                     }
-                    hasControl = await sensor.requestControl();
+                    hasControl = await sensor.requestControl(controlAbort.signal);
                     if (hasControl) {
                         this.logEvent( {message:'control granted', device:this.getName(), interface:this.getInterface()})
                         resolve( this.isStarting() )
                     }
-                    else {
+                    else if (!cancelled) {
                         await sleep(this.requestControlRetryDelay)
                     }
                 }
@@ -349,16 +366,22 @@ export default class BleFmAdapter extends BleAdapter<IndoorBikeData,BleFitnessMa
         // of relying entirely on the (much longer) shared outer pairing timeout to ever stop it. If it
         // is still starting (i.e. this isn't just an ordinary stop/interrupt) and control was never
         // granted within that window, fail fast with an explicit error.
+        //
+        // FIXES_BACKLOG #25: `onCancel` fires synchronously the moment this timeout (or an explicit
+        // stop of this task) gives up on `controlPromise` - used to abandon() the still in-flight
+        // requestControl() call above, so nothing from this generation keeps running afterward.
         const waitTask = new InteruptableTask<TaskState,boolean>( controlPromise, {
             timeout: this.requestControlTimeout,
             name: 'establishControl',
             errorOnTimeout: false,
-            log: this.logEvent.bind(this)
+            log: this.logEvent.bind(this),
+            onCancel: abandon
         })
 
         const granted = await waitTask.run()
 
         if (!granted && this.isStarting()) {
+            abandon()
             this.logEvent({message:'could not establish control', device:this.getName(), interface:this.getInterface()})
             throw new Error('could not establish control')
         }

--- a/src/ble/fm/adapter.unit.test.ts
+++ b/src/ble/fm/adapter.unit.test.ts
@@ -146,7 +146,10 @@ describe('BleFmAdapter',()=>{
             expect(sensor.startSensor).toHaveBeenCalledWith()
             expect(sensor.setCrr).toHaveBeenCalledWith(0.0036)
             expect(sensor.setCw).toHaveBeenCalledWith(0.35)
-            expect(sensor.requestControl).toHaveBeenCalledWith()
+            // FIXES_BACKLOG #25: establishControl() now passes its own cancellation signal into
+            // requestControl(), so its dedicated timeout can genuinely cancel this in-flight call
+            // instead of abandoning it - hence an AbortSignal argument, not a bare call.
+            expect(sensor.requestControl).toHaveBeenCalledWith(expect.any(AbortSignal))
             expect(sensor.setSlope).toHaveBeenCalledWith(0)
 
             // expected calls to interface
@@ -324,6 +327,123 @@ describe('BleFmAdapter',()=>{
             expect(checkCapabilities).toHaveBeenCalled()
             expect(waitForData).toHaveBeenCalled()
             expect(checkCapabilities.mock.invocationCallOrder[0]).toBeLessThan(waitForData.mock.invocationCallOrder[0])
+        })
+
+    })
+
+    // FIXES_BACKLOG #25: establishControl()'s own dedicated timeout must genuinely cancel the
+    // currently in-flight sensor.requestControl() call when it gives up, instead of just stopping
+    // its retry loop from iterating again - the in-flight call (and its underlying write) was
+    // previously left running in the background, on its own much longer internal timeline, and
+    // could outlive the entire adapter generation that spawned it (real-device log evidence: a
+    // RequestControl write issued before an establishControl timeout/adapter teardown only reported
+    // its own failure a full second after a brand new adapter cycle had already started).
+    describe('establishControl() cancels the in-flight requestControl() call on timeout (FIXES_BACKLOG #25)',()=>{
+
+        let sensor: BleFitnessMachineDevice
+        let ble: Partial<IBleInterface<any>>
+        let adapter: BleFmAdapter
+        let iv
+
+        const setupMocks = (a) => {
+            a.getSensor = jest.fn( ()=> sensor)
+            a.getBle = jest.fn().mockReturnValue(ble)
+            a.requestControlRetryDelay = 10
+        }
+
+        const emitDataContinuously = () => {
+            iv = setInterval( ()=> { sensor.emit('data',{power:0}) }, 10)
+        }
+
+        beforeEach( ()=>{
+            sensor = new BleFitnessMachineDevice(null)
+            sensor.subscribe = jest.fn().mockResolvedValue(true)
+            sensor.setCrr = jest.fn()
+            sensor.setCw = jest.fn()
+            sensor.hasPeripheral = jest.fn().mockReturnValue(true)
+            sensor.reset = jest.fn()
+            sensor.startSensor = jest.fn().mockReturnValue(true)
+            sensor.stopSensor = jest.fn().mockReturnValue(true)
+            sensor.setSlope = jest.fn().mockReturnValue(true)
+            sensor.setTargetPower = jest.fn().mockResolvedValue(true)
+
+            ble = {
+                once: jest.fn(),
+                pauseLogging: jest.fn(),
+                resumeLogging: jest.fn(),
+                removeListener: jest.fn(),
+                connect: jest.fn().mockResolvedValue(true),
+                createPeripheralFromSettings: jest.fn(),
+                waitForPeripheral: jest.fn().mockResolvedValue({})
+            }
+
+            adapter = new BleFmAdapter({interface:'ble', name:'1', address:'1111', protocol:'fm'})
+        })
+
+        afterEach( async ()=>{
+            if (iv)
+                clearInterval(iv)
+            await adapter.stop()
+        })
+
+        test('a still in-flight requestControl() call is genuinely aborted, not abandoned, once the dedicated timeout fires',async ()=>{
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0}   // stays controllable
+
+            let capturedSignal: AbortSignal|undefined
+            let abortObserved = false
+
+            // simulates a write that is genuinely stuck waiting for a GATT response that never
+            // arrives (e.g. a contended device that never answers RequestControl) - it only ever
+            // settles if/when it is told to abort, exactly like the real write()/writeFtmsMessage()
+            // chain now behaves (FIXES_BACKLOG #25)
+            sensor.requestControl = jest.fn().mockImplementation((signal?:AbortSignal) => {
+                capturedSignal = signal
+                return new Promise<boolean>( resolve => {
+                    signal?.addEventListener('abort', () => {
+                        abortObserved = true
+                        resolve(false)
+                    }, {once:true})
+                })
+            })
+            sensor.startRequest = jest.fn().mockResolvedValue(true)
+            setupMocks(adapter)
+            ;(adapter as any).requestControlTimeout = 50   // dedicated control timeout, kept short for the test
+            emitDataContinuously()
+
+            const result = await adapter.start({timeout:2000})
+
+            expect(result).toBe(false)
+            expect(adapter.started).toBeFalsy()
+
+            // the in-flight call must have genuinely been told to stop - not just left running
+            expect(capturedSignal).toBeInstanceOf(AbortSignal)
+            expect(capturedSignal!.aborted).toBe(true)
+            expect(abortObserved).toBe(true)
+        })
+
+        test('the retry loop does not issue a further requestControl() call once the dedicated timeout has fired',async ()=>{
+            sensor['_features'] = {fitnessMachine:0, targetSettings:0}
+
+            sensor.requestControl = jest.fn().mockImplementation((signal?:AbortSignal) => {
+                return new Promise<boolean>( resolve => {
+                    signal?.addEventListener('abort', () => resolve(false), {once:true})
+                })
+            })
+            sensor.startRequest = jest.fn().mockResolvedValue(true)
+            setupMocks(adapter)
+            ;(adapter as any).requestControlTimeout = 50
+            ;(adapter as any).requestControlRetryDelay = 10
+            emitDataContinuously()
+
+            await adapter.start({timeout:2000})
+
+            const callsAtGiveUp = (sensor.requestControl as any).mock.calls.length
+            expect(callsAtGiveUp).toBeGreaterThan(0)
+
+            // let plenty more time pass than the retry delay would need for another iteration -
+            // no further call should ever happen once establishControl() has given up
+            await sleep(100)
+            expect((sensor.requestControl as any).mock.calls.length).toBe(callsAtGiveUp)
         })
 
     })

--- a/src/ble/fm/sensor.ts
+++ b/src/ble/fm/sensor.ts
@@ -149,7 +149,7 @@ export default class BleFitnessMachineDevice extends TBleSensor {
         this.ftmsServiceDataAttempts = 0
     }
 
-    async requestControl(): Promise<boolean> {
+    async requestControl(signal?:AbortSignal): Promise<boolean> {
 
         if (this.hasControl) {
             return true;
@@ -171,7 +171,10 @@ export default class BleFitnessMachineDevice extends TBleSensor {
         const data = Buffer.alloc(1)
         data.writeUInt8(OpCode.RequestControl,0)
 
-        const res = await this.writeFtmsMessage(OpCode.RequestControl, data , {timeout:5000})
+        // FIXES_BACKLOG #25: an optional external cancellation signal - passed down by
+        // BleFmAdapter.establishControl() so its own dedicated timeout can genuinely cancel this
+        // specific in-flight write, instead of just abandoning it once establishControl() gives up.
+        const res = await this.writeFtmsMessage(OpCode.RequestControl, data , {timeout:5000, signal})
         if (res===OpCodeResult.Success) {
             this.hasControl = true
         }
@@ -722,17 +725,28 @@ export default class BleFitnessMachineDevice extends TBleSensor {
 
 
     protected async writeFtmsMessage(requestedOpCode:number, data:Buffer, props?:BleWriteProps) {
-        
+
         try {
             this.logEvent({message:'fmts:write', device:this.getName(), data:data.toString('hex')})
             let res:Buffer
             let tsStart  = Date.now()
             if (props?.timeout) {
+                // FIXES_BACKLOG #25: bound the underlying write() with its own AbortController, so
+                // that if this dedicated timeout fires, the in-flight write is genuinely cancelled
+                // (its 'data' listener removed, its promise settled) instead of being abandoned to
+                // run - and hold a listener on the shared characteristic - until its own eventual
+                // (much later, or non-existent) settlement. Merged with any externally supplied
+                // signal (e.g. from BleFmAdapter.establishControl()'s own dedicated timeout), so
+                // either giving up aborts this specific write.
+                const internalAbort = new AbortController()
+                const signal = props.signal ? AbortSignal.any([props.signal, internalAbort.signal]) : internalAbort.signal
+
                 res = await new InteruptableTask<TaskState,Buffer>(
-                    this.write( FTMS_CP, data, props ),
+                    this.write( FTMS_CP, data, {...props, signal} ),
                     {
                         timeout: props.timeout??800,
-                        errorOnTimeout: true
+                        errorOnTimeout: true,
+                        onCancel: () => internalAbort.abort()
                     }
                 ).run()
             }

--- a/src/ble/fm/sensor.unit.test.ts
+++ b/src/ble/fm/sensor.unit.test.ts
@@ -99,6 +99,109 @@ describe('BleFitnessMachineDevice',()=>{
     
 
 
+    // FIXES_BACKLOG #25: writeFtmsMessage()'s dedicated per-write timeout must genuinely cancel the
+    // underlying write() call it wraps, instead of abandoning it to keep running - and holding its
+    // 'data' listener on the shared characteristic - on its own (much longer, or non-existent) timeline.
+    describe('writeFtmsMessage / requestControl cancellation (FIXES_BACKLOG #25)',()=>{
+
+        let ftms:any
+
+        beforeEach( ()=>{
+            ftms = new BleFitnessMachineDevice(null,{id:'test'})
+            ftms.logEvent = jest.fn()
+            ftms.isSubscribed = jest.fn().mockReturnValue(true)
+        })
+
+        test('a dedicated write timeout aborts the underlying write() call, and resolves to OperationFailed (0x04)',async ()=>{
+            let capturedSignal: AbortSignal|undefined
+            ftms.write = jest.fn().mockImplementation( (_uuid:string,_data:Buffer,options:any) => {
+                capturedSignal = options?.signal
+                return new Promise<Buffer>( ()=>{} )   // never settles on its own - simulates a stuck GATT write
+            })
+
+            const data = Buffer.alloc(1)
+            const result = await ftms.writeFtmsMessage(0x00, data, {timeout:20})
+
+            expect(result).toBe(0x04)   // OpCodeResut.OperationFailed
+            expect(capturedSignal).toBeInstanceOf(AbortSignal)
+            expect(capturedSignal!.aborted).toBe(true)
+        })
+
+        test('an externally supplied signal (e.g. from establishControl()) also aborts the underlying write(), independent of the internal timeout',async ()=>{
+            let capturedSignal: AbortSignal|undefined
+            // mimics the real BlePeripheral.write(), which reacts to `options.signal` itself and
+            // rejects once it fires - here we only need to verify writeFtmsMessage() correctly
+            // forwards (merges) the externally supplied signal down into the call, not re-test
+            // write()'s own abort handling (already covered in peripheral.unit.test.ts)
+            ftms.write = jest.fn().mockImplementation( (_uuid:string,_data:Buffer,options:any) => {
+                capturedSignal = options?.signal
+                return new Promise<Buffer>( (_resolve,reject) => {
+                    options?.signal?.addEventListener('abort', ()=>reject(new Error('aborted')), {once:true})
+                })
+            })
+
+            const external = new AbortController()
+            const data = Buffer.alloc(1)
+            const promise = ftms.writeFtmsMessage(0x00, data, {timeout:5000, signal:external.signal})
+
+            external.abort()
+
+            const result = await promise
+            expect(result).toBe(0x04)   // OpCodeResut.OperationFailed
+            expect(capturedSignal?.aborted).toBe(true)
+        })
+
+        test('requestControl() forwards an external cancellation signal down to the underlying write()',async ()=>{
+            let capturedSignal: AbortSignal|undefined
+            ftms.write = jest.fn().mockImplementation( (_uuid:string,_data:Buffer,options:any) => {
+                capturedSignal = options?.signal
+                return new Promise<Buffer>( (_resolve,reject) => {
+                    options?.signal?.addEventListener('abort', ()=>reject(new Error('aborted')), {once:true})
+                })
+            })
+
+            const external = new AbortController()
+            const promise = ftms.requestControl(external.signal)
+
+            external.abort()
+
+            const hasControl = await promise
+            expect(hasControl).toBe(false)
+            expect(capturedSignal?.aborted).toBe(true)
+        })
+
+        test('setTargetPower() still resolves normally - unaffected by the listener-cleanup/cancellation changes',async ()=>{
+            ftms.hasControl = true   // control already granted -> requestControl() short-circuits to true
+            ftms.write = jest.fn().mockImplementation( (_uuid:string,_data:Buffer,_options:any) => {
+                const res = Buffer.alloc(3)
+                res.writeUInt8(0x80,0)          // ResponseCode
+                res.writeUInt8(0x05,1)          // request: SetTargetPower
+                res.writeUInt8(0x01,2)          // result: Success
+                return Promise.resolve(res)
+            })
+
+            const result = await ftms.setTargetPower(150)
+
+            expect(result).toBe(true)
+        })
+
+        test('startRequest() still resolves normally - unaffected by the listener-cleanup/cancellation changes',async ()=>{
+            ftms.hasControl = true
+            ftms.write = jest.fn().mockImplementation( (_uuid:string,_data:Buffer,_options:any) => {
+                const res = Buffer.alloc(3)
+                res.writeUInt8(0x80,0)          // ResponseCode
+                res.writeUInt8(0x07,1)          // request: StartOrResume
+                res.writeUInt8(0x01,2)          // result: Success
+                return Promise.resolve(res)
+            })
+
+            const result = await ftms.startRequest()
+
+            expect(result).toBe(true)
+        })
+
+    })
+
     describe('onDisconnect',()=>{})
 
     describe('parseHrm',()=>{})

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -183,6 +183,13 @@ export type BleCommsConnectProps = {
 export interface BleWriteProps {
     withoutResponse?: boolean;
     timeout?: number
+    /**
+     * Optional cancellation signal (FIXES_BACKLOG #25). When aborted while a write() is still
+     * waiting for its response, the in-flight write settles immediately and cleans up its own
+     * 'data' listener on the characteristic, instead of being abandoned until its own timeout
+     * (or forever, if none was given).
+     */
+    signal?: AbortSignal
 }
 
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -17,6 +17,16 @@ export interface TaskProps<T,P> {
     errorOnTimeout?:boolean
     log?: (event:any) => void
     onDone?: (state:T) => P
+
+    /**
+     * Side-effect hook invoked synchronously whenever this task gives up on the wrapped promise -
+     * either because its own timeout fired, or because it was explicitly stop()'d (never on natural
+     * completion/error of the wrapped promise itself). Unlike `onDone`, its return value is ignored;
+     * it exists purely so callers can signal cancellation (e.g. abort an AbortController) to whatever
+     * async work is still genuinely running underneath, instead of just abandoning it (FIXES_BACKLOG
+     * #25 - the same class of bug fixed for Adapter.start()/stop() in #23, applied one layer deeper).
+     */
+    onCancel?: () => void
 }
 
 interface InternalTaskState<P> {
@@ -39,6 +49,7 @@ export class InteruptableTask<T extends TaskState, P > {
     protected internalEvents = new EventEmitter()
     protected promise?:Promise<P>
     protected onStopNotifiers: Array<()=>void> = []
+    protected cancelNotified = false
 
     constructor(promise:Promise<any>, props?:TaskProps<T,P>   ) { 
         this.state = (props?.state??{}) as T;
@@ -112,9 +123,10 @@ export class InteruptableTask<T extends TaskState, P > {
 
                 this.sendStopNotification()
 
-                if (this.getState().result==='completed' || this.getState().result==='error') 
+                if (this.getState().result==='completed' || this.getState().result==='error')
                     return;
 
+                this.notifyCancel()
 
                 this.getState().result = 'stopped'
 
@@ -179,9 +191,11 @@ export class InteruptableTask<T extends TaskState, P > {
         if (!this.internalState.timeout) 
             return;
      
-        const message = this.props.name? `${this.props.name} timeout` : 'timeout';    
+        const message = this.props.name? `${this.props.name} timeout` : 'timeout';
         this.logEvent({message,active:this.isRunning()})
         this.clearTimeout()
+
+        this.notifyCancel()
 
         this.getState().result = 'timeout'
         const resolve = this.internalState.onDone
@@ -198,6 +212,18 @@ export class InteruptableTask<T extends TaskState, P > {
         else 
             resolve(null)
 
+    }
+
+    /**
+     * Invokes `onCancel` at most once per task, however many of timeout/explicit-stop paths reach
+     * it (e.g. an explicit stop() called after the timeout already fired independently) - so callers
+     * can rely on "cancelled at most once" without having to make their own handler idempotent.
+     */
+    protected notifyCancel() {
+        if (this.cancelNotified)
+            return
+        this.cancelNotified = true
+        this.props.onCancel?.()
     }
 
     protected sendStopNotification() {

--- a/src/utils/task.unit.test.ts
+++ b/src/utils/task.unit.test.ts
@@ -75,4 +75,58 @@ describe('InteruptableTask', ()=>{
 
     })
 
+    describe('onCancel (FIXES_BACKLOG #25)', ()=>{
+
+        // FIXES_BACKLOG #25: onCancel is the hook callers use to signal cancellation (e.g. abort an
+        // AbortController) to whatever is still genuinely running underneath, the moment this task
+        // itself gives up - either via its own timeout, or an explicit stop(). It must never fire on
+        // natural completion/error of the wrapped promise.
+
+        test('fires when the task times out', async ()=>{
+            const raw = new Promise<boolean>( ()=>{} )   // never settles on its own
+            const onCancel = vi.fn()
+
+            const task = new InteruptableTask<any,boolean>(raw, { timeout:10, errorOnTimeout:false, onCancel })
+
+            await task.run()
+
+            expect(onCancel).toHaveBeenCalledTimes(1)
+        })
+
+        test('fires when explicitly stopped', async ()=>{
+            const raw = new Promise<boolean>( ()=>{} )   // never settles on its own
+            const onCancel = vi.fn()
+
+            const task = new InteruptableTask<any,boolean>(raw, { errorOnTimeout:false, onCancel })
+
+            await task.stop()
+
+            expect(onCancel).toHaveBeenCalledTimes(1)
+        })
+
+        test('does not fire when the wrapped promise completes naturally', async ()=>{
+            const raw = Promise.resolve(true)
+            const onCancel = vi.fn()
+
+            const task = new InteruptableTask<any,boolean>(raw, { errorOnTimeout:false, onCancel })
+
+            await task.run()
+
+            expect(onCancel).not.toHaveBeenCalled()
+        })
+
+        test('does not fire a second time when stop() is called after a timeout already fired', async ()=>{
+            const raw = new Promise<boolean>( ()=>{} )
+            const onCancel = vi.fn()
+
+            const task = new InteruptableTask<any,boolean>(raw, { timeout:10, errorOnTimeout:false, onCancel })
+
+            await task.run()
+            await task.stop()
+
+            expect(onCancel).toHaveBeenCalledTimes(1)
+        })
+
+    })
+
 })


### PR DESCRIPTION
## Summary

Fixes `FIXES_BACKLOG` item #25. Builds on top of #23's not-yet-merged `fix/adapter-start-stop-race` (this PR targets that branch, not `main`), since it fixes the same class of bug one layer deeper.

Real-device testing of #23's fix (a controllable FTMS trainer already claimed by another BLE client, "Volt") surfaced two compounding defects that permanently wedged control acquisition until a full app restart:

1. **`BleFmAdapter.establishControl()`'s dedicated timeout didn't cancel its in-flight `RequestControl` write.** When the 10s dedicated timeout fired, it only stopped the retry loop from iterating again - the currently in-flight `sensor.requestControl()` call (and its underlying BLE write) kept running in the background on its own, much longer timeline, potentially outliving the entire adapter generation that spawned it. Proven by log evidence: a write issued before an `establishControl timeout`/adapter teardown only reported its own failure a full second after a brand new adapter cycle had already started.
2. **`BlePeripheral.write()` never removed its own `'data'` listener except on the success path**, via `c.removeAllListeners('data')` called inside the listener itself. An abandoned/timed-out write left its listener attached to the characteristic forever - and since the characteristic object is reused across adapter generations, a later real response would fire every stale listener, with the oldest one wiping out the current attempt's listener before it could ever see the response. This never self-heals within a running process - only a full app restart (fresh characteristic object) recovers it.

## What changed

- `src/utils/task.ts`: `InteruptableTask` gains an `onCancel` hook, invoked exactly once whenever a task gives up on its wrapped promise via timeout or explicit `stop()` - lets callers signal cancellation to whatever async work is still running underneath (mirrors #23's `getUnderlyingPromise()`, one layer deeper).
- `src/ble/base/peripheral.ts`: `write()` accepts an optional `AbortSignal` (via `BleWriteProps.signal`, added in `src/ble/types.ts`) and removes only its own listener reference on every exit path - success, write-callback error, or abort - never `removeAllListeners`.
- `src/ble/fm/sensor.ts`: `writeFtmsMessage()` bounds its own `write()` call with an `AbortController` tied via `onCancel` to its per-write timeout, merged (`AbortSignal.any`) with any externally supplied signal. `requestControl()` accepts an optional external signal and forwards it through.
- `src/ble/fm/adapter.ts`: `establishControl()` creates its own `AbortController`, passed into each `sensor.requestControl()` retry call, and aborted via `onCancel` the moment its dedicated timeout (or an adapter stop) gives up - so no `requestControl()` call from that generation keeps running after `establishControl()` throws.

## Test plan

- [x] `npm test` - full suite passes (53 test files, 1138 tests, 35 pre-existing skips)
- [x] `npx tsc -p tsconfig.esm.json --noEmit` - clean
- [x] New/updated tests:
  - `src/utils/task.unit.test.ts` - `onCancel` fires on timeout and explicit stop, never on natural completion, and at most once
  - `src/ble/base/peripheral.unit.test.ts` (new) - abandoned/aborted write leaves no dangling listener; success/error paths clean up correctly; **critical regression test**: an earlier abandoned write does not steal or discard a later, unrelated write's real response
  - `src/ble/fm/sensor.unit.test.ts` - `writeFtmsMessage()`/`requestControl()` genuinely abort the underlying write on timeout or external signal; `setTargetPower()`/`startRequest()` unaffected
  - `src/ble/fm/adapter.unit.test.ts` - `establishControl()`'s dedicated timeout genuinely aborts the in-flight `requestControl()` call and the retry loop issues no further calls afterward; existing test updated (`requestControl` is now called with an `AbortSignal` argument, not zero args)
- [x] **Real BLE hardware validated** - the multi-client contention scenario (mobile holds control, desktop attempts to pair, mobile releases control) confirmed: desktop now recovers on a subsequent retry without an app restart.

## Follow-up fix during hardware validation

The initial implementation used `c.removeListener('data', onData)` for per-write listener cleanup. On real hardware (desktop, WebBLE binding) this threw an uncaught `TypeError: c.removeListener is not a function` - the WebBLE characteristic shim implements `on()`/`off()`/`removeAllListeners()` but not the legacy `removeListener()` alias. Invisible to unit tests since the test mock is a real Node `EventEmitter` (which has both names). Fixed by using `c.off()` instead - already the established convention elsewhere in this file (`subscribe()`/`unsubscribe()`).


