### PR TITLE
fix: invalidate stale BLE characteristic cache entries on re-discovery (FIXES_BACKLOG #30)

### DIFF
--- a/src/ble/base/peripheral.ts
+++ b/src/ble/base/peripheral.ts
@@ -473,18 +473,30 @@ export class BlePeripheral implements IBlePeripheral {
         }
     }
 
-    async discoverAllCharacteristics():Promise<string[]> {   
-        try {     
+    async discoverAllCharacteristics():Promise<string[]> {
+        try {
             const {name,address} = this.getInfo()
 
             this.logEvent({message:'discover all characteristics',name,address})
 
 
-            const res = await this.getPeripheral().discoverSomeServicesAndCharacteristicsAsync([],[])                
+            const res = await this.getPeripheral().discoverSomeServicesAndCharacteristicsAsync([],[])
 
             const found:string[] = []
             const uuids:string[] = []
-            
+
+            // FIXES_BACKLOG #30: this call queries ALL characteristics on the device, so its result
+            // is a complete, authoritative picture of what the live GATT connection currently exposes.
+            // A UUID that was cached from an earlier round but is not reconfirmed here is stale (the
+            // device/adapter no longer serves it on this connection) and must be dropped - otherwise
+            // subscribe()/read()/write() would keep handing out a dead characteristic reference instead
+            // of falling through to their existing "not found" handling.
+            const freshUuids = new Set(res.characteristics.map(c => beautifyUUID(c.uuid)))
+            Object.keys(this.characteristics).forEach( existing => {
+                if (!freshUuids.has(existing))
+                    delete this.characteristics[existing]
+            })
+
             res.characteristics.forEach(c => {
                 this.characteristics[beautifyUUID(c.uuid)] = c
                 found.push(c.uuid)
@@ -494,7 +506,7 @@ export class BlePeripheral implements IBlePeripheral {
             this.logEvent({message:'discover all characteristics result',name,address,uuids:uuids.join('|')})
 
 
-            return found        
+            return found
         }
         catch(err) {
             this.logEvent( {message:'Error', fn:'discoverAllCharacteristics', error:err.message, stack:err.stack})
@@ -502,17 +514,28 @@ export class BlePeripheral implements IBlePeripheral {
         }
     }
 
-    async discoverSomeCharacteristics(characteristics:string[]):Promise<string[]> {   
-        try {     
+    async discoverSomeCharacteristics(characteristics:string[]):Promise<string[]> {
+        try {
             const target = characteristics.map(c=> fullUUID(c))
-            const res = await this.getPeripheral().discoverSomeServicesAndCharacteristicsAsync([],target)                
+            const res = await this.getPeripheral().discoverSomeServicesAndCharacteristicsAsync([],target)
 
             const found = []
+
+            // FIXES_BACKLOG #30: this call targets a specific set of UUIDs - any of the requested
+            // UUIDs not reconfirmed by this fresh, targeted discovery is stale and must be removed
+            // from the cache, rather than continuing to serve a dead reference from an earlier round.
+            const freshUuids = new Set(res.characteristics.map(c => beautifyUUID(c.uuid)))
+            characteristics.forEach( requested => {
+                const requestedUuid = beautifyUUID(requested)
+                if (!freshUuids.has(requestedUuid))
+                    delete this.characteristics[requestedUuid]
+            })
+
             res.characteristics.forEach(c => {
                 this.characteristics[beautifyUUID(c.uuid)] = c
                 found.push(c.uuid)
             });
-            return found        
+            return found
         }
         catch(err) {
             this.logEvent( {message:'Error', fn:'discoverAllCharacteristics', error:err.message, stack:err.stack})

--- a/src/ble/base/peripheral.unit.test.ts
+++ b/src/ble/base/peripheral.unit.test.ts
@@ -151,4 +151,150 @@ describe('BlePeripheral', () => {
 
     })
 
+    describe('discoverAllCharacteristics/discoverSomeCharacteristics cache invalidation (FIXES_BACKLOG #30)', () => {
+
+        const IBD = '2AD2'   // FTMS Indoor Bike Data
+        const FMS = '2ADA'   // FTMS FM Status
+        const CP2 = '2AD9'   // FTMS Control Point - never found in any round in the real repro
+
+        const setup = () => {
+            const announcement: any = { peripheral: { id: 'p1', address: 'AA:BB:CC:DD:EE:FF' }, serviceUUIDs: [] }
+            const p: any = new BlePeripheral(announcement)
+            p.connected = true
+            p.logEvent = () => {}
+
+            const peripheral = {
+                id: 'p1',
+                address: 'AA:BB:CC:DD:EE:FF',
+                discoverSomeServicesAndCharacteristicsAsync: vi.fn(),
+            }
+            p.getPeripheral = () => peripheral
+
+            return { p, peripheral }
+        }
+
+        test('discoverAllCharacteristics: a characteristic present in an earlier round and absent from a later one is dropped from the cache', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+            const fms = new MockChar(FMS)
+
+            // round 1: both found, get cached
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd, fms] })
+            await p.discoverAllCharacteristics()
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+            expect(p.getRawCharacteristic(FMS)).toBe(fms)
+
+            // round 2, same live connection: only IBD reconfirmed, FMS is no longer returned
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+            await p.discoverAllCharacteristics()
+
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+            expect(p.getRawCharacteristic(FMS)).toBeUndefined()
+        })
+
+        test('discoverAllCharacteristics: a characteristic that stays present across rounds is unaffected', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+            await p.discoverAllCharacteristics()
+
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+            await p.discoverAllCharacteristics()
+
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+        })
+
+        test('discoverAllCharacteristics: a first-ever discovery still populates the cache normally', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+            const fms = new MockChar(FMS)
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd, fms] })
+
+            expect(p.getRawCharacteristic(IBD)).toBeUndefined()
+
+            const found = await p.discoverAllCharacteristics()
+
+            expect(found).toEqual([IBD, FMS])
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+            expect(p.getRawCharacteristic(FMS)).toBe(fms)
+        })
+
+        test('discoverAllCharacteristics: reproduces the real repro - a characteristic never found in any round (Control Point) stays absent, while a reconfirmed-then-dropped one (FM Status) is removed', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+            const fms = new MockChar(FMS)
+
+            // round 1: empty
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [] })
+            await p.discoverAllCharacteristics()
+
+            // round 2: real characteristics found and cached, CP2 still absent
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd, fms] })
+            await p.discoverAllCharacteristics()
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+            expect(p.getRawCharacteristic(FMS)).toBe(fms)
+
+            // round 3 (lazily triggered by write() looking for CP2): empty again
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [] })
+            await p.discoverAllCharacteristics()
+
+            expect(p.getRawCharacteristic(IBD)).toBeUndefined()
+            expect(p.getRawCharacteristic(FMS)).toBeUndefined()
+            expect(p.getRawCharacteristic(CP2)).toBeUndefined()
+        })
+
+        test('discoverSomeCharacteristics: a requested characteristic absent from a fresh targeted discovery is dropped from the cache', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+            const fms = new MockChar(FMS)
+
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd, fms] })
+            await p.discoverSomeCharacteristics([IBD, FMS])
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+            expect(p.getRawCharacteristic(FMS)).toBe(fms)
+
+            // same connection, later targeted re-discovery of the same two UUIDs: FMS no longer found
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+            await p.discoverSomeCharacteristics([IBD, FMS])
+
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+            expect(p.getRawCharacteristic(FMS)).toBeUndefined()
+        })
+
+        test('discoverSomeCharacteristics: a characteristic that stays present across rounds is unaffected', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+            await p.discoverSomeCharacteristics([IBD])
+
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+            await p.discoverSomeCharacteristics([IBD])
+
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+        })
+
+        test('discoverSomeCharacteristics: a first-ever discovery still populates the cache normally', async () => {
+            const { p, peripheral } = setup()
+
+            const ibd = new MockChar(IBD)
+            peripheral.discoverSomeServicesAndCharacteristicsAsync.mockResolvedValueOnce({ services: [], characteristics: [ibd] })
+
+            expect(p.getRawCharacteristic(IBD)).toBeUndefined()
+
+            const found = await p.discoverSomeCharacteristics([IBD])
+
+            expect(found).toEqual([IBD])
+            expect(p.getRawCharacteristic(IBD)).toBe(ibd)
+        })
+
+    })
+
 })


### PR DESCRIPTION
## Summary

`BlePeripheral`'s characteristic cache (`this.characteristics`, `src/ble/base/peripheral.ts`) was additive-only: `discoverAllCharacteristics()` and `discoverSomeCharacteristics()` merged fresh GATT discovery results into the cache, but nothing ever removed an entry that a *later* discovery on the same live connection failed to reconfirm. The cache was only ever reset wholesale, on `disconnect()`.

Root cause confirmed via a real desktop session log (app v26.7.5, device `SCH130/230`, a trainer downgraded to Power-Meter-only): within one connection, `discoverAllCharacteristics()` for the Fitness Machine Service (`1826`) was called three times — 1st: empty; 2nd (~700ms later): returns real `2AD2`/`2ADA`/etc., which get cached; 3rd (triggered lazily by `write()`'s attempt to find the Control Point `2AD9`, never found in any round): empty again. `subscribeSelected()` then looked up the stale-but-cached `2AD2`/`2ADA` objects and called `.subscribe()` on them, which round-tripped over IPC to the desktop app and failed with a misleading `"device not found"` — pairing then silently stalled waiting for data that would never arrive.

This is the same underlying live-GATT-discovery-race already tracked in `FIXES_BACKLOG` item #26 (scoped to mobile/RN, and to *detecting* the mismatch as a connection failure). This PR is purely the cache-staleness half of the problem, implemented independently on its own terms.

## What changed

- `discoverAllCharacteristics()`: since this call queries *all* characteristics on the device, its result is now treated as a complete, authoritative snapshot — any previously cached UUID not reconfirmed by the fresh result is removed from `this.characteristics` before the fresh result is merged in.
- `discoverSomeCharacteristics()`: since this call targets a specific set of UUIDs, any of *those* requested UUIDs not reconfirmed by the fresh, targeted discovery is removed from the cache (UUIDs outside the requested set are left untouched, since this call says nothing about their current validity).
- No changes to `subscribeSelected()`/`subscribe()`/`read()`/`write()`/`getRawCharacteristic()` — they already fall through correctly to their existing "not found" handling once a stale entry is removed from the cache.
- No changes to `adapter.ts`/`interface.ts` (item #26's territory) — kept scope strictly to the cache itself.

## Test plan

- Added unit tests in `src/ble/base/peripheral.unit.test.ts`:
  - a characteristic present in an earlier round and absent from a later one (both for `discoverAllCharacteristics()` and `discoverSomeCharacteristics()`) is no longer returned by `getRawCharacteristic()`
  - a characteristic that stays present across rounds is unaffected
  - a first-ever discovery still populates the cache normally
  - a reproduction of the real repro sequence (empty → real characteristics cached → empty again), confirming the previously-cached entries are dropped while a characteristic never found in any round (Control Point) correctly stays absent throughout
- `npm test` (vitest): 53 test files, 1146 passed, 35 skipped — all green.

**Outstanding:** real-hardware validation against an actual downgraded FTMS device (trainer/rower reporting no settable target) was not possible in this environment and still needs to be done by the user before merging.

## Related

Companion desktop PR (small diagnostic-wording fix for the same item, in `subscribeRequest()`'s "characteristic not found" log path): incyclist/desktop#197
