### PR TITLE
fix: BLE FTMS pairing fails when a self-powered device has just powered on

### DIFF
--- a/src/ble/base/adapter.ts
+++ b/src/ble/base/adapter.ts
@@ -521,7 +521,19 @@ export default class BleAdapter<TDeviceData extends BleDeviceData, TDevice exten
         const sensor = this.getSensor();
         let connected = await sensor.startSensor()
 
-        await sensor.subscribe()
+        const subscribed = await sensor.subscribe()
+
+        // FIXES_BACKLOG #26: subscribe() can come back false even though the physical BLE connect
+        // just succeeded - e.g. BlePeripheral.subscribeSelected() detected that a service the
+        // peripheral advertised didn't show up in discovery (self-powered device still finishing
+        // GATT server init after just powering back on) and cleanly failed/disconnected instead of
+        // subscribing against an incomplete characteristic table. Treat that the same as a failed
+        // connection attempt: don't wire up data/disconnect listeners or attempt pair()/RequestControl
+        // against a device we know is incompletely discovered - let startAdapter() report this as a
+        // clean connection failure so the outer retry loop performs a genuinely fresh reconnect.
+        if (connected && !subscribed) {
+            connected = false
+        }
 
         if(connected) {
             sensor.on('data',this.onDeviceDataHandler) 

--- a/src/ble/base/peripheral.ts
+++ b/src/ble/base/peripheral.ts
@@ -15,6 +15,14 @@ export class BlePeripheral implements IBlePeripheral {
     protected disconnectedSignalled: boolean = false
     protected discoveredServiceUUIds: Array<string>|undefined
 
+    // FIXES_BACKLOG #26: set by discoverServices() whenever a service the peripheral advertised
+    // (BlePeripheralAnnouncement.serviceUUIDs, captured at scan time) is missing from the live
+    // discoverServicesAsync() result - a self-powered device that has *just* powered back on can
+    // advertise before its GATT server has actually finished registering the Fitness Machine
+    // Service. subscribeSelected() consults this flag to fail the connection attempt cleanly
+    // instead of proceeding against an incomplete characteristic table.
+    protected serviceDiscoveryIncomplete: boolean = false
+
     protected discoverServicesPromise: Promise<string[]>|undefined
     protected discoverCharacteristicsPromise: Record<string,Promise<BleCharacteristic[]>|undefined> = {}
 
@@ -220,12 +228,13 @@ export class BlePeripheral implements IBlePeripheral {
         sleep(0).then(()=> { delete this.discoverServicesPromise} )
 
         const isComplete = this.checkAnnouncedServices(res)
+        this.serviceDiscoveryIncomplete = !isComplete
         if (!isComplete) {
-            this.logEvent({message:'service data incomplete - disconnecting'})
-            //this.getPeripheral().emit('disconnect')
-            
+            const {name,address} = this.getInfo()
+            this.logEvent({message:'service data incomplete - disconnecting', name, address,
+                announced:this.getAnnouncedServices(), discovered:this.getDiscoveredServices()})
         }
-        
+
         return res
 
     }
@@ -435,7 +444,24 @@ export class BlePeripheral implements IBlePeripheral {
             catch {}
         }
 
-        
+        // FIXES_BACKLOG #26: an advertised service that didn't show up in discovery means the
+        // peripheral's GATT server (most likely) hasn't finished initializing yet - proceeding to
+        // discoverAllCharacteristics()/subscribe() here would only ever find a partial (or empty)
+        // characteristic table for it. Fail this connection attempt cleanly instead: disconnect (so
+        // the physical BLE connection is genuinely torn down, not left half-subscribed) and reset the
+        // cached discovery state, so the *next* connection attempt performs a real, fresh discovery
+        // rather than reusing this incomplete result or re-hitting a live-connection GATT cache.
+        if (this.serviceDiscoveryIncomplete) {
+            this.logEvent({message:'peripheral subscribe selected failed', uuids, reason:'service discovery incomplete',
+                announced:this.getAnnouncedServices(), discovered:this.getDiscoveredServices()})
+
+            this.discoveredServiceUUIds = undefined
+            this.serviceDiscoveryIncomplete = false
+
+            await this.disconnect().catch(()=>{})
+            return false
+        }
+
         try {
             if (Object.keys(this.characteristics).length===0) {
                 await this.discoverAllCharacteristics();

--- a/src/ble/base/peripheral.unit.test.ts
+++ b/src/ble/base/peripheral.unit.test.ts
@@ -31,6 +31,45 @@ class MockChar extends EventEmitter implements BleCharacteristic {
 
 const CP = '2AD9'   // FTMS Control Point - the shared characteristic at the centre of FIXES_BACKLOG #25
 
+// FTMS UUIDs at the centre of FIXES_BACKLOG #26 - a rower advertises the Fitness Machine Service
+// (1826) but, if it just powered back on, its GATT server may not have finished registering it yet.
+const FTMS = '1826'
+const ROWER_DATA = '2AD1'
+const CONTROL_POINT = '2AD9'
+const FM_STATUS = '2ADA'
+
+// Minimal noble-style raw peripheral mock - a plain EventEmitter, matching
+// `BleRawPeripheral extends EventEmitter` (src/ble/types.ts). `discovered` drives what
+// discoverServicesAsync()/discoverSomeServicesAndCharacteristicsAsync() report back, independent of
+// what the peripheral advertised (captured separately in the announcement passed to BlePeripheral).
+class MockRawPeripheral extends EventEmitter {
+    id: string
+    address: string
+    services: any[] = []
+    advertisement: any = {}
+    state = 'connected'
+    discovered: Array<{ uuid: string }> = []
+
+    constructor(id = 'p1', address = 'AA:BB:CC:DD:EE:FF') {
+        super()
+        this.id = id
+        this.address = address
+    }
+
+    async connectAsync(): Promise<void> {}
+    async disconnectAsync(): Promise<void> {}
+    disconnect(cb: (err?: Error) => void): Promise<void> {
+        cb()
+        return Promise.resolve()
+    }
+    async discoverServicesAsync(_serviceUUIDs: string[]) {
+        return this.discovered
+    }
+    async discoverSomeServicesAndCharacteristicsAsync(_serviceUUIDs: string[], _characteristicUUIDs: string[]) {
+        return { services: this.discovered, characteristics: [] }
+    }
+}
+
 describe('BlePeripheral', () => {
 
     describe('write (FIXES_BACKLOG #25)', () => {
@@ -147,6 +186,81 @@ describe('BlePeripheral', () => {
             // B must resolve with the real response - not be silently discarded by A's cleanup
             await expect(writeB).resolves.toEqual(realResponse)
             expect(c.listenerCount('data')).toBe(0)
+        })
+
+    })
+
+    describe('subscribeSelected - service discovery vs advertisement mismatch (FIXES_BACKLOG #26)', () => {
+
+        // e.g. a rower that just powered back on: it advertises 1826 (Fitness Machine Service),
+        // but its GATT server hasn't finished registering it yet by the time discovery runs.
+        const setup = (announcedServices: string[], discoveredServices: string[]) => {
+            const raw = new MockRawPeripheral()
+            raw.discovered = discoveredServices.map(uuid => ({ uuid }))
+
+            const announcement: any = { peripheral: raw, serviceUUIDs: announcedServices, advertisement: {} }
+            const p: any = new BlePeripheral(announcement)
+            p.connected = true
+            p.logEvent = () => {}
+
+            // pre-populate characteristics so subscribeSelected() skips discoverAllCharacteristics()
+            // and has real notify-capable characteristics available to (attempt to) subscribe to
+            const chars = [ROWER_DATA, CONTROL_POINT, FM_STATUS].map(uuid => new MockChar(uuid))
+            p.characteristics = Object.fromEntries(chars.map(c => [beautifyUUID(c.uuid), c]))
+
+            return { p, raw, chars }
+        }
+
+        test('a discovered service list missing an advertised service fails the connection attempt instead of subscribing', async () => {
+            const { p } = setup([FTMS], [])   // advertised FTMS, but discovery came back without it
+
+            const subscribeSpy = vi.spyOn(p, 'subscribe')
+
+            const result = await p.subscribeSelected([ROWER_DATA, CONTROL_POINT, FM_STATUS], () => {})
+
+            expect(result).toBe(false)
+            expect(subscribeSpy).not.toHaveBeenCalled()
+
+            // the peripheral must be torn down, not left half-subscribed, so the next connection
+            // attempt performs a genuinely fresh discovery rather than reusing this incomplete result
+            expect(p.isConnected()).toBe(false)
+        })
+
+        test('a discovered service list that also contains unrelated/extra services still fails when the advertised one is missing', async () => {
+            const { p } = setup([FTMS], ['180A'])  // some other, unrelated service was found - still no FTMS
+
+            const subscribeSpy = vi.spyOn(p, 'subscribe')
+
+            const result = await p.subscribeSelected([ROWER_DATA, CONTROL_POINT, FM_STATUS], () => {})
+
+            expect(result).toBe(false)
+            expect(subscribeSpy).not.toHaveBeenCalled()
+        })
+
+        test('a discovered service list matching the advertisement proceeds to subscribe as today', async () => {
+            const { p } = setup([FTMS], [FTMS])
+
+            const subscribeSpy = vi.spyOn(p, 'subscribe').mockResolvedValue(true)
+
+            const result = await p.subscribeSelected([ROWER_DATA, CONTROL_POINT, FM_STATUS], () => {})
+
+            expect(result).toBe(true)
+            expect(subscribeSpy).toHaveBeenCalledTimes(3)
+            expect(p.isConnected()).toBe(true)
+        })
+
+        test('an advertisement with no announced services (advertisement-less) proceeds to subscribe as today', async () => {
+            // some devices (e.g. older Tacx) don't advertise their service UUIDs at all - nothing to
+            // verify discovery against, so this must never be treated as a mismatch
+            const { p, raw } = setup([], [])
+            raw.discovered = [{ uuid: FTMS }]   // discovery still finds the real GATT table
+
+            const subscribeSpy = vi.spyOn(p, 'subscribe').mockResolvedValue(true)
+
+            const result = await p.subscribeSelected([ROWER_DATA, CONTROL_POINT, FM_STATUS], () => {})
+
+            expect(result).toBe(true)
+            expect(subscribeSpy).toHaveBeenCalledTimes(3)
         })
 
     })

--- a/src/ble/base/sensor.ts
+++ b/src/ble/base/sensor.ts
@@ -102,6 +102,15 @@ export class TBleSensor extends EventEmitter implements IBleSensor {
         this.connectPromise = this.connectPromise ?? this.peripheral.connect()
 
         const connected = await this.connectPromise
+
+        // FIXES_BACKLOG #26: clear the cached promise once it has settled (mirrors
+        // BlePeripheral.connect()'s own pattern). This field only exists to dedupe *concurrent*
+        // calls into startSensor() - leaving it set forever after the first call would mean a later,
+        // separate startSensor() call (e.g. a retry after this peripheral was deliberately
+        // disconnected because service discovery came back incomplete) never re-invokes
+        // peripheral.connect() at all, so a genuinely fresh reconnect attempt could never happen.
+        delete this.connectPromise
+
         if (!connected)
             return false
 


### PR DESCRIPTION
## Summary

Fixes FIXES_BACKLOG item #26.

BLE FTMS pairing could fail for a self-powered device (e.g. a rower that powers off after inactivity and back on when the user starts moving) that has *just* powered on, even though it correctly advertises the Fitness Machine Service (`1826`) in its BLE advertisement.

Root cause (confirmed via real-device evidence, discussed and agreed with the user): a live GATT protocol race on the device side — its advertisement payload (static firmware data) is available before its actual GATT server has finished registering the Fitness Machine Service after power-on. Previously, `BlePeripheral.subscribeSelected()` proceeded to `discoverAllCharacteristics()`/`subscribe()` anyway when this happened, silently finding none of the FTMS characteristics (`2AD1`/`2AD9`/`2ADA`), which produced `cannot subscribe, reason:'not found'` and caused `requestControl()` to fail almost instantly.

## What changed

- **`src/ble/base/peripheral.ts`** — `discoverServices()` now compares the peripheral's advertised `serviceUuids` against the services actually returned by `_discoverServices()` and sets a `serviceDiscoveryIncomplete` flag when an advertised service is missing. `subscribeSelected()` checks this flag and, if set, fails the connection attempt cleanly: disconnects the peripheral and resets the cached discovery state, instead of proceeding against an incomplete characteristic table.
- **`src/ble/base/adapter.ts`** — `BleAdapter.startSensor()` now captures `sensor.subscribe()`'s return value (previously discarded) and treats a `false` result as a failed connection attempt, skipping the data/disconnect listener wiring and `pair()`/`RequestControl` call. This lets `startAdapter()` report a clean connection failure for the existing outer retry/reconnect loop to pick up on the next attempt, by which point the device has had more real time to finish initializing its GATT server.
- **`src/ble/base/sensor.ts`** — `TBleSensor.startSensor()` now clears its cached `connectPromise` once settled (mirroring `BlePeripheral.connect()`'s own pattern). Without this, a later retry after our new disconnect would never re-invoke `peripheral.connect()` at all — the "fresh reconnect" the fix relies on could never actually happen for a long-lived adapter instance reused across retries.

Per the agreed design, this deliberately does **not**:
- rely on `BleManager.refreshCache()` (rejected — see FIXES_BACKLOG #26 discussion)
- retry `discoverServices()` in a loop on the same live connection (rejected — Android's native stack can serve a within-connection cached result without a real re-query)

## Test plan

- [x] Added unit tests in `src/ble/base/peripheral.unit.test.ts`:
  - a discovered service list missing an advertised service fails the connection attempt and never calls `subscribe()`
  - a discovered list containing unrelated/extra services still fails when the advertised service itself is missing
  - a matching discovered/advertised list proceeds to subscribe as before
  - an advertisement-less peripheral (no announced `serviceUuids`) proceeds to subscribe as before
- [x] `npm test` — full suite green (1143 passed, 35 skipped, 53 files)
- [x] `npm run build` — esm + cjs compile cleanly
- [ ] **Outstanding**: real-device validation against the actual rower (`MRK-R15-D829`) is **not possible in this environment** — needs manual validation by the user (launch while device is powered off, power it on mid-retry, confirm pairing succeeds on the next automatic retry without an app restart) before merging.