### PR TITLE
fix: bound Wahoo-CP writes with a timeout so a missing GATT notify doesn't hang pairing

### DIFF
--- a/src/ble/wahoo/sensor.ts
+++ b/src/ble/wahoo/sensor.ts
@@ -7,6 +7,14 @@ import { IndoorBikeData } from "../fm/index.js";
 import BleFitnessMachineDevice from "../fm/sensor.js";
 import { BleProtocol, BleWriteProps  } from "../types.js";
 import { beautifyUUID} from "../utils.js";
+import { InteruptableTask, TaskState } from "../../utils/task.js";
+
+// Wahoo-CP writes (e.g. setSimMode/0x43) don't reliably trigger a GATT notify response on every
+// firmware (confirmed on the KICKR SNAP) - unlike unlock/requestControl, which uses its own longer
+// (10s) budget for the initial handshake. Bound every other Wahoo-CP write to this shorter duration
+// so a missing notify fails just that single write (non-fatal to callers) instead of hanging the
+// whole pairing flow indefinitely.
+const WAHOO_CP_WRITE_TIMEOUT = 800; // ms
 
 export default class BleWahooDevice extends BleFitnessMachineDevice {
     static readonly profile: LegacyProfile = 'Smart Trainer'
@@ -298,28 +306,54 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
     }
 
     protected async writeWahooFtmsMessage(requestedOpCode:number, data:Buffer,props?:BleWriteProps) {
-        
+
         try {
 
             const opcode = Buffer.alloc(1)
             opcode.writeUInt8(requestedOpCode,0)
             const message = Buffer.concat( [opcode,data])
             this.logEvent({message:'wahoo cp:write', data:message.toString('hex')})
-           
-            const res = await this.write( this.wahooCP, message,props )
 
+            let res:Buffer
+
+            if (props?.timeout) {
+                // Mirrors BleFitnessMachineDevice.writeFtmsMessage()'s bounded-write pattern
+                // (FIXES_BACKLOG #25): some Wahoo-CP opcodes (e.g. setSimMode/0x43 on the KICKR SNAP)
+                // never trigger a GATT notify response, so an unguarded await here can hang forever,
+                // silently consuming the whole outer pairing timeout even while the trainer is
+                // already connected and streaming real data. Bound the underlying write() with its
+                // own AbortController-backed timeout, so a missing notify fails just this single
+                // write - non-fatal to the caller - instead of the entire startAdapter() chain.
+                const internalAbort = new AbortController()
+                const combined = new AbortController()
+                props.signal?.addEventListener('abort', () => combined.abort(), {once:true})
+                internalAbort.signal.addEventListener('abort', () => combined.abort(), {once:true})
+                const signal = combined.signal
+
+                res = await new InteruptableTask<TaskState,Buffer>(
+                    this.write( this.wahooCP, message, {...props, signal} ),
+                    {
+                        timeout: props.timeout,
+                        errorOnTimeout: true,
+                        onCancel: () => internalAbort.abort()
+                    }
+                ).run()
+            }
+            else {
+                res = await this.write( this.wahooCP, message, props )
+            }
 
             const responseData = Buffer.from(res)
             const result = responseData.readUInt8(0)
             //const opCode = responseData.readUInt8(1)
             return result===1;
 
-            
+
         }
         catch(err) {
             this.logEvent({message:'wahoo cp:write failed', opCode: requestedOpCode, reason: err.message})
             return false
-        } 
+        }
     }
 
     // Wahoo has a minimum interval between ERG writes to the trainer to give it time to react and apply a new setting.
@@ -348,7 +382,7 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
             const data = Buffer.alloc(2)
             data.writeInt16LE( Math.round(power), 0)
             
-            const res = await this.writeWahooFtmsMessage(OpCode.setErgMode, data )
+            const res = await this.writeWahooFtmsMessage(OpCode.setErgMode, data, {timeout:WAHOO_CP_WRITE_TIMEOUT} )
             if (res===true) {
                 this.setPowerAdjusting();
                 this.data.targetPower = power;
@@ -390,7 +424,7 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
             data.writeInt16LE( Math.round(crr*10000), 2)
             data.writeInt16LE( Math.round(cw*1000), 4)
             
-            const res = await this.writeWahooFtmsMessage(OpCode.setSimMode, data )
+            const res = await this.writeWahooFtmsMessage(OpCode.setSimMode, data, {timeout:WAHOO_CP_WRITE_TIMEOUT} )
 
             this.isSimMode = true;
             this.simModeSettings={weight,crr,cw}
@@ -409,8 +443,8 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
             const data = Buffer.alloc(2)
             data.writeInt16LE( Math.round(crr*10000), 0)
             
-            const res = await this.writeWahooFtmsMessage(OpCode.setSimCRR, data )
-            return res;            
+            const res = await this.writeWahooFtmsMessage(OpCode.setSimCRR, data, {timeout:WAHOO_CP_WRITE_TIMEOUT} )
+            return res;
         }
         catch(err) {
             this.logEvent({message:'error',fn:'setSimCRR', error:err.message||err, stack:err.stack})
@@ -426,8 +460,8 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
             const data = Buffer.alloc(2)
             data.writeInt16LE( Math.round(cw*1000), 0)
             
-            const res = await this.writeWahooFtmsMessage(OpCode.setSimWindResistance, data )
-            return res;            
+            const res = await this.writeWahooFtmsMessage(OpCode.setSimWindResistance, data, {timeout:WAHOO_CP_WRITE_TIMEOUT} )
+            return res;
         }
         catch(err) {
             this.logEvent({message:'error',fn:'setSimWindResistance', error:err.message||err, stack:err.stack})
@@ -450,8 +484,8 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
             const data = Buffer.alloc(2)
             data.writeUInt16LE( slopeVal, 0)
 
-            const res = await this.writeWahooFtmsMessage(OpCode.setSimGrade, data )
-            return res;            
+            const res = await this.writeWahooFtmsMessage(OpCode.setSimGrade, data, {timeout:WAHOO_CP_WRITE_TIMEOUT} )
+            return res;
         }
         catch(err) {
             this.logEvent({message:'error',fn:'setSimGrade', error:err.message||err, stack:err.stack})
@@ -468,8 +502,8 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
             const data = Buffer.alloc(2)
             data.writeInt16LE( Math.round(value), 0)
             
-            const res = await this.writeWahooFtmsMessage(OpCode.setSimWindSpeed, data )
-            return res;            
+            const res = await this.writeWahooFtmsMessage(OpCode.setSimWindSpeed, data, {timeout:WAHOO_CP_WRITE_TIMEOUT} )
+            return res;
         }
         catch(err:any) {
             this.logEvent({message:'error',fn:'setSimWindSpeed', error:err.message||err, stack:err.stack})
@@ -478,13 +512,37 @@ export default class BleWahooDevice extends BleFitnessMachineDevice {
 
     }
 
-    async setWheelCircumference(wheelCircumference: number): Promise<void> {        
+    async setWheelCircumference(wheelCircumference: number): Promise<void> {
         this.wheelCircumference = wheelCircumference
     }
     getWheelCircumference(): number {
         return this.wheelCircumference
     }
 
+    // Wahoo devices (CSP + Wahoo-proprietary Trainer CP only) never expose the FTMS service, so the
+    // inherited BleFitnessMachineDevice implementations of these would always try characteristic
+    // 2ad9, fail (characteristic not found) and log a guaranteed, spurious failure on every single
+    // Wahoo pairing. Slope/power/resistance control already happens through the Wahoo-proprietary CP
+    // (setSlope()/setTargetPower()/setSimMode() etc.), so these are safe, silent no-ops here.
 
+    async startRequest(): Promise<boolean> {
+        return true;
+    }
+
+    async stopRequest(): Promise<boolean> {
+        return true;
+    }
+
+    async PauseRequest(): Promise<boolean> {
+        return true;
+    }
+
+    async setTargetInclination(_inclination: number): Promise<boolean> {
+        return true;
+    }
+
+    async setTargetResistanceLevel(_resistanceLevel: number): Promise<boolean> {
+        return true;
+    }
 
 }

--- a/src/ble/wahoo/sensor.unit.test.ts
+++ b/src/ble/wahoo/sensor.unit.test.ts
@@ -16,34 +16,34 @@ describe ( 'WahooAdvancedFmAdapter',()=>{
         test('0%',async ()=>{
 
             await c.setSimGrade(0)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('0080','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('0080','hex'),{timeout:800})
 
         })
 
         test('-100%',async ()=>{
 
             await c.setSimGrade(-100)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('0000','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('0000','hex'),{timeout:800})
 
         })
         test('-0.5%',async ()=>{
 
             await c.setSimGrade(-0.5)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('5c7f','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('5c7f','hex'),{timeout:800})
 
         })
 
         test('2%',async ()=>{
 
             await c.setSimGrade(2)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('8f82','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('8f82','hex'),{timeout:800})
 
         })
 
         test('8%',async ()=>{
 
             await c.setSimGrade(8)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('3d8a','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('3d8a','hex'),{timeout:800})
 
         })
 
@@ -51,21 +51,21 @@ describe ( 'WahooAdvancedFmAdapter',()=>{
         test('< -100%',async ()=>{
 
             await c.setSimGrade(-125)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('0000','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('0000','hex'),{timeout:800})
 
         })
 
         test('100%',async ()=>{
 
             await c.setSimGrade(100)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('ffff','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('ffff','hex'),{timeout:800})
 
         })
 
         test('> 100%',async ()=>{
-  
+
             await c.setSimGrade(180)
-            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('FFFF','hex'))
+            expect(c.writeWahooFtmsMessage).toHaveBeenCalledWith(OpCode.setSimGrade,Buffer.from('FFFF','hex'),{timeout:800})
 
         })
 
@@ -78,11 +78,67 @@ describe ( 'WahooAdvancedFmAdapter',()=>{
             const dataSpy = jest.fn();
             const c = new WahooSensor({logger:MockLogger});
             c.on('data',dataSpy)
-            const data = Buffer.from( '14000000000000000000d503','hex') 
+            const data = Buffer.from( '14000000000000000000d503','hex')
             c.onData('0x2a63',data)
 
-            expect(dataSpy).toHaveBeenCalledWith({instantaneousPower:0,raw:'2a63:14000000000000000000d503'})            
+            expect(dataSpy).toHaveBeenCalledWith({instantaneousPower:0,raw:'2a63:14000000000000000000d503'})
 
         })
+    })
+
+    // bug repro: a KICKR SNAP acks 'unlock' but never sends a notify for setSimMode (opcode 0x43) -
+    // writeWahooFtmsMessage() previously had no way to bound that wait at all, so setSlope() (called
+    // from initControl()'s sendInitialRequest() step) hung forever, silently consuming the whole 30s
+    // pairing window even while the trainer was already connected and streaming real power data.
+    describe( 'writeWahooFtmsMessage bounded timeout (setSimMode never notifies)', ()=> {
+
+        let c
+
+        beforeEach( ()=>{
+            c = new WahooSensor({logger:MockLogger});
+            c.logEvent = jest.fn()
+        })
+
+        test('a dedicated write timeout aborts the underlying write() call, and resolves to false',async ()=>{
+            let capturedSignal: AbortSignal|undefined
+            c.write = jest.fn().mockImplementation( (_uuid:string,_message:Buffer,options:any) => {
+                capturedSignal = options?.signal
+                return new Promise<Buffer>( ()=>{} )   // never settles - simulates a missing GATT notify
+            })
+
+            const data = Buffer.alloc(6)
+            const result = await c.writeWahooFtmsMessage(OpCode.setSimMode, data, {timeout:20})
+
+            expect(result).toBe(false)
+            expect(capturedSignal).toBeInstanceOf(AbortSignal)
+            expect(capturedSignal!.aborted).toBe(true)
+        })
+
+        test('setSlope() completes well within the timeout budget (not 30s) when the trainer acks unlock but never notifies on setSimMode',async ()=>{
+            const ackUnlock = Buffer.from([1])   // OpCodeResult success byte the Wahoo CP replies with
+
+            c.write = jest.fn().mockImplementation( (_uuid:string, message:Buffer) => {
+                const opcode = message.readUInt8(0)
+                if (opcode===OpCode.unlock) {
+                    return Promise.resolve(ackUnlock)
+                }
+                // setSimMode (and anything else): trainer never notifies - simulates the KICKR SNAP
+                return new Promise<Buffer>( ()=>{} )
+            })
+
+            const start = Date.now()
+            const result = await c.setSlope(5)
+            const duration = Date.now()-start
+
+            // bounded by the per-write timeout (800ms) instead of hanging until the outer 30s pairing
+            // budget is exhausted
+            expect(duration).toBeLessThan(5000)
+            // setSimMode never got acked -> setSlope() reports failure, but resolves rather than hangs
+            expect(result).toBe(false)
+            // the setSimMode write was genuinely attempted (and given up on), not skipped
+            const simModeCall = c.write.mock.calls.find( ([,message]:[string,Buffer]) => message.readUInt8(0)===OpCode.setSimMode)
+            expect(simModeCall).toBeDefined()
+        }, 10000)
+
     })
 })


### PR DESCRIPTION
## Summary

- BLE pairing to a Wahoo KICKR SNAP timed out after the full 30s pairing window even though the trainer was already connected and streaming real power data throughout.
- Root cause: `BleWahooDevice.setSimMode()` writes opcode `0x43` (`setSimMode`) via `writeWahooFtmsMessage()` with no timeout. On the KICKR SNAP that opcode never triggers a GATT notify response, and `BlePeripheral.write()` has no built-in timeout of its own, so the `await` hangs forever - consuming the entire outer pairing budget before `waitForInitialData()` (the step that would have succeeded off the already-arriving power data) is ever reached.
- A secondary finding while tracing this: `writeWahooFtmsMessage()` never actually *consumed* the `timeout` prop - it just forwarded `props` straight into `write()`, so `requestControl()`'s existing `{timeout:10000}` was already inert in practice too, not just missing on `setSimMode()`.

## What changed

- `writeWahooFtmsMessage()` (`src/ble/wahoo/sensor.ts`) now genuinely enforces `props.timeout`, mirroring `BleFitnessMachineDevice.writeFtmsMessage()`'s bounded-write pattern (`InteruptableTask` + `AbortController`, FIXES_BACKLOG #25 style). A timeout aborts the in-flight `write()` (removing its listener on the shared characteristic) and resolves the call to `false` rather than throwing further up - non-fatal to callers.
- Every Wahoo-CP write call site that was missing a timeout now passes one (`WAHOO_CP_WRITE_TIMEOUT = 800ms`, matching the FM adapter's own per-write constant): `setErgMode`, `setSimMode`, `setSimCRR`, `setSimWindResistance`, `setSimGrade`, `setSimWindSpeed`. `requestControl()`'s existing `10000ms` unlock-handshake budget is unchanged, but is now actually enforced.
- Added no-op overrides on `BleWahooDevice` for `startRequest()`, `stopRequest()`, `PauseRequest()`, `setTargetInclination()`, `setTargetResistanceLevel()`. These are inherited from `BleFitnessMachineDevice` and always target the FTMS Control Point (`2ad9`), which Wahoo devices never expose (CSP + Wahoo-proprietary Trainer CP only) - so they previously logged a guaranteed, spurious failure on every single Wahoo pairing. Slope/power control already happens through the Wahoo-proprietary CP (`setSlope()`/`setTargetPower()`/`setSimMode()`).
- Not touched: the separate, already-correctly-handled FTMS `startRequest()` (`2ad9`) failure noted in the original investigation - that failure path was already logged/discarded/non-fatal; this PR's no-op overrides simply prevent it from being attempted at all on Wahoo devices going forward.

## Test plan

- [x] `npm test` - full suite passes (53 test files, 1152 tests, 35 pre-existing skipped).
- [x] New unit tests in `src/ble/wahoo/sensor.unit.test.ts`:
  - `writeWahooFtmsMessage()` with a dedicated timeout aborts the underlying `write()` (signal fires) and resolves to `false` instead of hanging.
  - Repro of the actual bug: a mocked peripheral that acks `unlock` but never notifies on `setSimMode` - `setSlope()` (the real call chain from `initControl()`'s `sendInitialRequest()` step) now completes well within the timeout budget instead of hanging, and confirms the `setSimMode` write was genuinely attempted.
- [x] Existing `setSimGrade` tests updated to expect the new `{timeout:800}` argument on `writeWahooFtmsMessage()`.
- [x] `npx tsc --noEmit -p tsconfig.esm.json` - no type errors.